### PR TITLE
Fix global leak.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Module exports
-module.exports = iconv = {
+var iconv = module.exports = {
     toEncoding: function(str, encoding) {
         return iconv.getCodec(encoding).toEncoding(str);
     },


### PR DESCRIPTION
`iconv` variable was being leaked into the `global` namespace because it hadn't been declared with `var`.
