### PR TITLE
Add Windows936 Encoding Mapping

### DIFF
--- a/encodings/gbk.js
+++ b/encodings/gbk.js
@@ -1,5 +1,6 @@
 var gbkTable = require(__dirname + '/table/gbk.js');
 module.exports = {
+	'windows936': 'gbk',
 	'gb2312': 'gbk',
 	'gbk': {
 		type: 'table',


### PR DESCRIPTION
tedious used iconv-lite , while connecting chinese version mssql server, throw an exception : windows936 is unrecognized encoding.
windows936 encoding can use gbk to be  decoded correctly
