### PR TITLE
Optimized table and internal encoding use "single-byte" way.

### DIFF
--- a/test/perfomance.js
+++ b/test/perfomance.js
@@ -2,14 +2,24 @@
 var iconv = require('iconv');
 var iconv_lite = require("../index");
 
-var encoding = "windows-1251";
+var encoding = process.argv[2] || "windows-1251";
 var convertTimes = 1000;
 
+var encodingStrings = {
+    'windows-1251': 'This is a test string 32 chars..',
+    'gbk': '这是中文字符测试。。！@￥%',
+    'utf8': '这是中文字符测试。。！@￥%This is a test string 32 chars..',
+};
 // Test encoding.
-var str = "This is a test string 32 chars..";
-for (var i = 0; i < 13; i++)
+var str = encodingStrings[encoding];
+if (!str) {
+    throw new Error('Don\'t support ' + encoding + ' performance test.');
+}
+for (var i = 0; i < 13; i++) {
     str = str + str;
+}
 
+console.log('\n' + encoding + ' charset performance test:');
 console.log("\nEncoding "+str.length+" chars "+convertTimes+" times:");
 
 var start = Date.now();


### PR DESCRIPTION
Optimized before:

``` bash
$ node test/perfomance.js gbk

gbk charset performance test:

Encoding 114688 chars 1000 times:
iconv: 7278ms, 15.39 Mb/s.
iconv-lite: 7136ms, 15.70 Mb/s.

Decoding 212992 bytes 1000 times:
iconv: 8569ms, 24.27 Mb/s.
iconv-lite: 8061ms, 25.80 Mb/s.
```

<hr/>

after:

``` bash
$ node test/perfomance.js gbk

gbk charset performance test:

Encoding 114688 chars 1000 times:
iconv: 7231ms, 15.49 Mb/s.
iconv-lite: 7067ms, 15.85 Mb/s.

Decoding 212992 bytes 1000 times:
iconv: 8017ms, 25.94 Mb/s.
iconv-lite: 2109ms, 98.62 Mb/s.
```

And I also let `test/performance.js` support charset params, just run `$ node test/performance.js [encoding]`, default encoding is "windows-1251".
e.g.:

``` bash
$ node test/performance.js
$ node test/performance.js utf8
$ node test/performance.js gbk
```
