### PR TITLE
Update package.json to use latest version of iconv

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     },
     "devDependencies": {
         "vows": "",
-        "iconv": "1.1"
+        "iconv": ">=1.1"
     }
 }


### PR DESCRIPTION
Iconv 1.1 has a bug on node v0.8 which is patched in 1.2.0.
