### PR TITLE
Make require('iconv-lite') fast

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,17 @@ var iconv = module.exports = {
     
     defaultCharUnicode: '�',
     defaultCharSingleByte: '?',
+
+    encodingsLoaded: false,
     
     // Get correct codec for given encoding.
     getCodec: function(encoding) {
+        if (!iconv.encodingsLoaded) {
+            applyEncodings(require('./encodings/singlebyte'));
+            applyEncodings(require('./encodings/gbk'));
+            applyEncodings(require('./encodings/big5'));
+            iconv.encodingsLoaded = true;
+        }
         var enc = encoding || "utf8";
         var codecOptions = undefined;
         while (1) {
@@ -192,9 +200,6 @@ function applyEncodings(encodings) {
         iconv.encodings[key] = encodings[key]
 }
 
-applyEncodings(require('./encodings/singlebyte'));
-applyEncodings(require('./encodings/gbk'));
-applyEncodings(require('./encodings/big5'));
 
 
 // Utilities


### PR DESCRIPTION
Requiring iconv-lite is costly due to the library loading the encodings. This fixes that by lazy-loading them.

Before:

```
node -e "require('node-iconv')"  0.18s user 0.02s system 98% cpu 0.204 total
```

After:

```
node -e "require('node-iconv')"  0.07s user 0.01s system 97% cpu 0.081 total
```
