### PR TITLE
Map Big5-HKSCS to Big5

### DIFF
--- a/encodings/big5.js
+++ b/encodings/big5.js
@@ -2,6 +2,7 @@ var big5Table = require('./table/big5.js');
 module.exports = {
 	'windows950': 'big5',
 	'cp950': 'big5',
+	'big5hkscs': 'big5',
 	'big5': {
 		type: 'table',
 		table: big5Table


### PR DESCRIPTION
Note this is a naive mapping only, no extra characters are added.

To really support HKSCS, please refer to:  
http://www.ogcio.gov.hk/en/business/tech_promotion/ccli/hkscs/
http://www.ogcio.gov.hk/en/business/tech_promotion/ccli/terms/doc/New2003cmp_2008.txt
