### PR TITLE
Add default encoding of utf8.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ iconv.getCodec = function getCodec(encoding) {
         iconv.encodings = require("../encodings"); // Lazy load all encoding definitions.
     
     // Canonicalize encoding name: strip all non-alphanumeric chars and appended year.
-    var enc = (''+encoding).toLowerCase().replace(/[^0-9a-z]|:\d{4}$/g, "");
+    var enc = (''+encoding).toLowerCase().replace(/[^0-9a-z]|:\d{4}$/g, "") || "utf8";
 
     // Traverse iconv.encodings to find actual codec.
     var codecData, codecOptions;


### PR DESCRIPTION
was wondering if you'd be interested in restoring the [previous default](https://github.com/ashtuchkin/iconv-lite/blob/v0.2.11/index.js#L24) for `getCodec`.
