### PR TITLE
do not throw an error if `extendNodeEncodings()` is called again

### DIFF
--- a/lib/extend-node.js
+++ b/lib/extend-node.js
@@ -5,8 +5,7 @@ module.exports = function (iconv) {
     var original = undefined; // Place to keep original methods.
 
     iconv.extendNodeEncodings = function extendNodeEncodings() {
-        if (original)
-            throw new Error("require('iconv-lite').extendNodeEncodings() is already called.")
+        if (original) return;
         original = {};
 
         var nodeNativeEncodings = {


### PR DESCRIPTION
Rationale:
- My package [`fidonet-jam`](https://www.npmjs.org/package/fidonet-jam) currently [uses](https://github.com/Mithgol/node-fidonet-jam/blob/8cc852e2e51dfcb68d79ab20989cf3efd07e9d41/fidonet-jam.js#L6) `require('iconv-lite').extendNodeEncodings()`
- My package [`simteconf`](https://www.npmjs.org/package/simteconf) currently [uses](https://github.com/Mithgol/simteconf/blob/4f5646eb445bcae7f06e028b0502bff358ab26b5/simteconf.js#L9) `require('iconv-lite').extendNodeEncodings()`
- One of my applications ([PhiDo](https://github.com/Mithgol/phido)) currently [uses](https://github.com/Mithgol/phido/blob/7f7516e9e21102b06a174cd1db55c3ecffd98a73/package.json#L14-17) both of these packages, though not their current versions. It should probably not throw an error on start even if I decide to upgrade them both.
