### PR TITLE
use g++-4.8 (support C++11) and start testing against Node.js version 4.0 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
    - "0.11"
    - "0.12"
    - "iojs"
+   - "4.0"
 
  before_install:
    - "test $TRAVIS_NODE_VERSION != '0.8' || npm install -g npm@1.2.8000"


### PR DESCRIPTION
This pull request adds Node.js version 4.0 testing.

I've noticed that the tests fail on io.js and Node 4.0.

There are **two** separate problems here.

**The first problem** is that the `iconv` package (needed for testing) won't build.

I've thought (initially) that these engine versions need a newer toolchain environment setting (`CXX=g++-4.8`) as implied by travis-ci/travis-ci#4771 and netiam/experiments@b700b5176bd185a272c7c21c24bbc4fa6a3e36bd, but the actual problem seems to be something else.

**The second problem** is that the iconv-lite's behaviour is itself not quite right.

I have performed some manual testing on Windows in Node.js v4.0.0, and the results don't seem correct:

![(screenshot)](https://cloud.githubusercontent.com/assets/1088720/9797875/3109a4b8-5806-11e5-8bcf-6a0ed1c12de0.gif)

[The Pile of Poo Test™](https://mathiasbynens.be/notes/javascript-unicode#poo-test) seems to fail.

The results of such test were good enough in Node.js v0.12.x and v0.10.x where the result of `Buffer('\uD83D\uDCA9', 'cp866').toString('cp866')` was `'??'` (i.e. one question mark for each half of the surrogate pair).