### PR TITLE
Version locking async to 1.5.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "request": "2.47",
         "unorm": "*",
         "errto": "*",
-        "async": "*",
+        "async": "1.5.2",
         "istanbul": "*",
         "iconv": "2.1"
     }


### PR DESCRIPTION
There are breaking changes ( https://github.com/caolan/async/blob/master/CHANGELOG.md#breaking-changes ) in the latest version and iconv-lite doesn't version lock to `1.x`