### PR TITLE
Add files fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",
+    "files": ["./encodings", "./generation"],
     "homepage": "https://github.com/ashtuchkin/iconv-lite",
     "bugs": "https://github.com/ashtuchkin/iconv-lite/issues",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",
-    "files": ["./encodings", "./generation"],
+    "files": ["./encodings", "./lib", "./Changelog.md"],
     "homepage": "https://github.com/ashtuchkin/iconv-lite",
     "bugs": "https://github.com/ashtuchkin/iconv-lite/issues",
     "repository": {


### PR DESCRIPTION
packaging tools like [npm2deb](https://github.com/LeoIannacone/npm2deb) relies on package.json to get list of required directories other than `lib`. It would ease packaging of module if package.json has all the relevant data.