### PR TITLE
Add more internal aliases

### DIFF
--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -12,6 +12,14 @@ module.exports = {
     utf16le: "ucs2",
 
     binary: { type: "_internal" },
+    latin1: "binary",
+    iso88591: "binary",
+    csisolatin1: "binary",
+    l1: "binary",
+    isoir100: "binary",
+    cp819: "binary",
+    ibm819: "binary",
+
     base64: { type: "_internal" },
     hex:    { type: "_internal" },
 


### PR DESCRIPTION
Node's 'binary' encoding is really latin1. In fact, 'latin1' has been the new name for the 'binary' encoding in node core for some time now. This commit adds the various 'latin1' aliases to use the internal 'binary' encoding instead of this module's implementation.