### PR TITLE
Fix TypeScript typings regression

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,9 +6,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 declare module 'iconv-lite' {
-	export function decode(buffer: NodeBuffer, encoding: string, options?: Options): string;
+	export function decode(buffer: Buffer, encoding: string, options?: Options): string;
 
-	export function encode(content: string, encoding: string, options?: Options): NodeBuffer;
+	export function encode(content: string, encoding: string, options?: Options): Buffer;
 
 	export function encodingExists(encoding: string): boolean;
 


### PR DESCRIPTION
https://github.com/ashtuchkin/iconv-lite/commit/8fd550d0b33c0131c60c746b7bb7dd40ab002503 changed `Buffer` to `NodeBuffer`, which [is deprecated](https://sourcegraph.com/github.com/DefinitelyTyped/DefinitelyTyped/-/blob/types/node/index.d.ts#L648-649) and is not present in types/env-node.