### PR TITLE
Fix crash during debugging React Native apps.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,9 @@ iconv.getDecoder = function getDecoder(encoding, options) {
 
 
 // Load extensions in Node. All of them are omitted in Browserify build via 'browser' field in package.json.
-var nodeVer = typeof process !== 'undefined' && process.versions && process.versions.node;
+// Also omitted in debugging React Native apps by: typeof navigator === 'undefined'
+// Note: in React Native environment: navigator.product === 'ReactNative'
+var nodeVer = typeof navigator === 'undefined' && typeof process !== 'undefined' && process.versions && process.versions.node;
 if (nodeVer) {
 
     // Load streaming support in Node v0.10+


### PR DESCRIPTION
While I am debugging JS codes (by Visual Studio Code 1.19.1) of my React Native Windows app through RN packager, I get this error message:
![iconv-lite](https://user-images.githubusercontent.com/12458706/34399185-e3de4c98-ebbf-11e7-80a1-cbee0e119154.png)
This is my package.json.
```
  "dependencies": {
    "axios": "^0.17.1",
    "babel-core": "^7.0.0-beta.3",
    "buffer": "^5.0.8",
    "cheerio-without-node-native": "^0.20.2",
    "iconv-lite": "^0.4.19",
    "react": "16.0.0",
    "react-native": "~0.51.0",
    "react-native-code-push": "^5.2.1",
    "react-native-windows": "^0.51.0-rc.0",
    "react-navigation": "^1.0.0-beta.22",
    "react-redux": "^5.0.6",
    "react-test-renderer": "16.2.0",
    "redux": "^3.7.2",
    "redux-logger": "^3.0.6",
    "redux-promise-middleware": "^5.0.0",
    "redux-thunk": "^2.2.0",
    "stream": "^0.0.2"
  },
```
I guess the React Native environment needs not the extension for Node at the 132-th line in lib/index.js. Thus, I use the variable, navigator, to exclude the React Native environment...
Now, I can correctly launch my React Native apps in debugging mode.