### PR TITLE
Fix the paths in "browser" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
         "test": "mocha --reporter spec --grep ."
     },
     "browser": {
-        "./extend-node": false,
-        "./streams": false
+        "./lib/extend-node": false,
+        "./lib/streams": false
     },
     "devDependencies": {
         "mocha": "*",


### PR DESCRIPTION
Those paths are relative to `package.json`, and the files are in the `lib` directory.