### PR TITLE
Use Buffer.(from|alloc) instead of deprecated Buffer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 var iconv = require('iconv-lite');
 
 // Convert from an encoded buffer to js string.
-str = iconv.decode(new Buffer([0x68, 0x65, 0x6c, 0x6c, 0x6f]), 'win1251');
+str = iconv.decode(Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f]), 'win1251');
 
 // Convert from js string to an encoded buffer.
 buf = iconv.encode("Sample input string", 'win1251');

--- a/encodings/dbcs-codec.js
+++ b/encodings/dbcs-codec.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 // Multibyte codec. In this scheme, a character is represented by 1 or more bytes.
 // Our codec supports UTF-16 surrogates, extensions for GB18030 and unicode sequences.
@@ -281,7 +281,7 @@ function DBCSEncoder(options, codec) {
 }
 
 DBCSEncoder.prototype.write = function(str) {
-    var newBuf = new Buffer(str.length * (this.gb18030 ? 4 : 3)), 
+    var newBuf = Buffer.alloc(str.length * (this.gb18030 ? 4 : 3)),
         leadSurrogate = this.leadSurrogate,
         seqObj = this.seqObj, nextChar = -1,
         i = 0, j = 0;
@@ -404,7 +404,7 @@ DBCSEncoder.prototype.end = function() {
     if (this.leadSurrogate === -1 && this.seqObj === undefined)
         return; // All clean. Most often case.
 
-    var newBuf = new Buffer(10), j = 0;
+    var newBuf = Buffer.alloc(10), j = 0;
 
     if (this.seqObj) { // We're in the sequence.
         var dbcsCode = this.seqObj[DEF_CHAR];
@@ -440,7 +440,7 @@ DBCSEncoder.prototype.findIdx = findIdx;
 function DBCSDecoder(options, codec) {
     // Decoder state
     this.nodeIdx = 0;
-    this.prevBuf = new Buffer(0);
+    this.prevBuf = Buffer.alloc(0);
 
     // Static data
     this.decodeTables = codec.decodeTables;
@@ -450,7 +450,7 @@ function DBCSDecoder(options, codec) {
 }
 
 DBCSDecoder.prototype.write = function(buf) {
-    var newBuf = new Buffer(buf.length*2),
+    var newBuf = Buffer.alloc(buf.length*2),
         nodeIdx = this.nodeIdx, 
         prevBuf = this.prevBuf, prevBufOffset = this.prevBuf.length,
         seqStart = -this.prevBuf.length, // idx of the start of current parsed sequence.
@@ -527,7 +527,7 @@ DBCSDecoder.prototype.end = function() {
         var buf = this.prevBuf.slice(1);
 
         // Parse remaining as usual.
-        this.prevBuf = new Buffer(0);
+        this.prevBuf = Buffer.alloc(0);
         this.nodeIdx = 0;
         if (buf.length > 0)
             ret += this.write(buf);

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 // Export Node.js internal encodings.
 
@@ -33,7 +33,7 @@ function InternalCodec(codecOptions, iconv) {
         this.encoder = InternalEncoderCesu8;
 
         // Add decoder for versions of Node not supporting CESU-8
-        if (new Buffer('eda0bdedb2a9', 'hex').toString() !== '💩') {
+        if (Buffer.from('eda0bdedb2a9', 'hex').toString() !== '💩') {
             this.decoder = InternalDecoderCesu8;
             this.defaultCharUnicode = iconv.defaultCharUnicode;
         }
@@ -67,7 +67,7 @@ function InternalEncoder(options, codec) {
 }
 
 InternalEncoder.prototype.write = function(str) {
-    return new Buffer(str, this.enc);
+    return Buffer.from(str, this.enc);
 }
 
 InternalEncoder.prototype.end = function() {
@@ -87,11 +87,11 @@ InternalEncoderBase64.prototype.write = function(str) {
     this.prevStr = str.slice(completeQuads);
     str = str.slice(0, completeQuads);
 
-    return new Buffer(str, "base64");
+    return Buffer.from(str, "base64");
 }
 
 InternalEncoderBase64.prototype.end = function() {
-    return new Buffer(this.prevStr, "base64");
+    return Buffer.from(this.prevStr, "base64");
 }
 
 
@@ -102,7 +102,7 @@ function InternalEncoderCesu8(options, codec) {
 }
 
 InternalEncoderCesu8.prototype.write = function(str) {
-    var buf = new Buffer(str.length * 3), bufIdx = 0;
+    var buf = Buffer.alloc(str.length * 3), bufIdx = 0;
     for (var i = 0; i < str.length; i++) {
         var charCode = str.charCodeAt(i);
         // Naive implementation, but it works because CESU-8 is especially easy

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 // Single-byte codec. Needs a 'chars' string parameter that contains 256 or 128 chars that
 // correspond to encoded bytes (if 128 - then lower half is ASCII). 
@@ -20,11 +20,10 @@ function SBCSCodec(codecOptions, iconv) {
         codecOptions.chars = asciiString + codecOptions.chars;
     }
 
-    this.decodeBuf = new Buffer(codecOptions.chars, 'ucs2');
+    this.decodeBuf = new Buffer.from(codecOptions.chars, 'ucs2');
     
     // Encoding buffer.
-    var encodeBuf = new Buffer(65536);
-    encodeBuf.fill(iconv.defaultCharSingleByte.charCodeAt(0));
+    var encodeBuf = new Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0));
 
     for (var i = 0; i < codecOptions.chars.length; i++)
         encodeBuf[codecOptions.chars.charCodeAt(i)] = i;
@@ -41,7 +40,7 @@ function SBCSEncoder(options, codec) {
 }
 
 SBCSEncoder.prototype.write = function(str) {
-    var buf = new Buffer(str.length);
+    var buf = Buffer.alloc(str.length);
     for (var i = 0; i < str.length; i++)
         buf[i] = this.encodeBuf[str.charCodeAt(i)];
     
@@ -59,7 +58,7 @@ function SBCSDecoder(options, codec) {
 SBCSDecoder.prototype.write = function(buf) {
     // Strings are immutable in JS -> we use ucs2 buffer to speed up computations.
     var decodeBuf = this.decodeBuf;
-    var newBuf = new Buffer(buf.length*2);
+    var newBuf = Buffer.alloc(buf.length*2);
     var idx1 = 0, idx2 = 0;
     for (var i = 0; i < buf.length; i++) {
         idx1 = buf[i]*2; idx2 = i*2;

--- a/encodings/utf16.js
+++ b/encodings/utf16.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 // Note: UTF16-LE (or UCS2) codec is Node.js native. See encodings/internal.js
 
@@ -20,7 +20,7 @@ function Utf16BEEncoder() {
 }
 
 Utf16BEEncoder.prototype.write = function(str) {
-    var buf = new Buffer(str, 'ucs2');
+    var buf = Buffer.from(str, 'ucs2');
     for (var i = 0; i < buf.length; i += 2) {
         var tmp = buf[i]; buf[i] = buf[i+1]; buf[i+1] = tmp;
     }
@@ -41,7 +41,7 @@ Utf16BEDecoder.prototype.write = function(buf) {
     if (buf.length == 0)
         return '';
 
-    var buf2 = new Buffer(buf.length + 1),
+    var buf2 = Buffer.alloc(buf.length + 1),
         i = 0, j = 0;
 
     if (this.overflowByte !== -1) {

--- a/encodings/utf7.js
+++ b/encodings/utf7.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 // UTF-7 codec, according to https://tools.ietf.org/html/rfc2152
 // See also below a UTF-7-IMAP codec, according to http://tools.ietf.org/html/rfc3501#section-5.1.3
@@ -26,7 +26,7 @@ function Utf7Encoder(options, codec) {
 Utf7Encoder.prototype.write = function(str) {
     // Naive implementation.
     // Non-direct chars are encoded as "+<base64>-"; single "+" char is encoded as "+-".
-    return new Buffer(str.replace(nonDirectChars, function(chunk) {
+    return Buffer.from(str.replace(nonDirectChars, function(chunk) {
         return "+" + (chunk === '+' ? '' : 
             this.iconv.encode(chunk, 'utf16-be').toString('base64').replace(/=+$/, '')) 
             + "-";
@@ -75,7 +75,7 @@ Utf7Decoder.prototype.write = function(buf) {
                     res += "+";
                 } else {
                     var b64str = base64Accum + buf.slice(lastI, i).toString();
-                    res += this.iconv.decode(new Buffer(b64str, 'base64'), "utf16-be");
+                    res += this.iconv.decode(Buffer.from(b64str, 'base64'), "utf16-be");
                 }
 
                 if (buf[i] != minusChar) // Minus is absorbed after base64.
@@ -97,7 +97,7 @@ Utf7Decoder.prototype.write = function(buf) {
         base64Accum = b64str.slice(canBeDecoded); // The rest will be decoded in future.
         b64str = b64str.slice(0, canBeDecoded);
 
-        res += this.iconv.decode(new Buffer(b64str, 'base64'), "utf16-be");
+        res += this.iconv.decode(Buffer.from(b64str, 'base64'), "utf16-be");
     }
 
     this.inBase64 = inBase64;
@@ -109,7 +109,7 @@ Utf7Decoder.prototype.write = function(buf) {
 Utf7Decoder.prototype.end = function() {
     var res = "";
     if (this.inBase64 && this.base64Accum.length > 0)
-        res = this.iconv.decode(new Buffer(this.base64Accum, 'base64'), "utf16-be");
+        res = this.iconv.decode(Buffer.from(this.base64Accum, 'base64'), "utf16-be");
 
     this.inBase64 = false;
     this.base64Accum = '';
@@ -144,7 +144,7 @@ Utf7IMAPCodec.prototype.bomAware = true;
 function Utf7IMAPEncoder(options, codec) {
     this.iconv = codec.iconv;
     this.inBase64 = false;
-    this.base64Accum = new Buffer(6);
+    this.base64Accum = Buffer.alloc(6);
     this.base64AccumIdx = 0;
 }
 
@@ -152,7 +152,7 @@ Utf7IMAPEncoder.prototype.write = function(str) {
     var inBase64 = this.inBase64,
         base64Accum = this.base64Accum,
         base64AccumIdx = this.base64AccumIdx,
-        buf = new Buffer(str.length*5 + 10), bufIdx = 0;
+        buf = Buffer.alloc(str.length*5 + 10), bufIdx = 0;
 
     for (var i = 0; i < str.length; i++) {
         var uChar = str.charCodeAt(i);
@@ -198,7 +198,7 @@ Utf7IMAPEncoder.prototype.write = function(str) {
 }
 
 Utf7IMAPEncoder.prototype.end = function() {
-    var buf = new Buffer(10), bufIdx = 0;
+    var buf = Buffer.alloc(10), bufIdx = 0;
     if (this.inBase64) {
         if (this.base64AccumIdx > 0) {
             bufIdx += buf.write(this.base64Accum.slice(0, this.base64AccumIdx).toString('base64').replace(/\//g, ',').replace(/=+$/, ''), bufIdx);
@@ -246,7 +246,7 @@ Utf7IMAPDecoder.prototype.write = function(buf) {
                     res += "&";
                 } else {
                     var b64str = base64Accum + buf.slice(lastI, i).toString().replace(/,/g, '/');
-                    res += this.iconv.decode(new Buffer(b64str, 'base64'), "utf16-be");
+                    res += this.iconv.decode(Buffer.from(b64str, 'base64'), "utf16-be");
                 }
 
                 if (buf[i] != minusChar) // Minus may be absorbed after base64.
@@ -268,7 +268,7 @@ Utf7IMAPDecoder.prototype.write = function(buf) {
         base64Accum = b64str.slice(canBeDecoded); // The rest will be decoded in future.
         b64str = b64str.slice(0, canBeDecoded);
 
-        res += this.iconv.decode(new Buffer(b64str, 'base64'), "utf16-be");
+        res += this.iconv.decode(Buffer.from(b64str, 'base64'), "utf16-be");
     }
 
     this.inBase64 = inBase64;
@@ -280,7 +280,7 @@ Utf7IMAPDecoder.prototype.write = function(buf) {
 Utf7IMAPDecoder.prototype.end = function() {
     var res = "";
     if (this.inBase64 && this.base64Accum.length > 0)
-        res = this.iconv.decode(new Buffer(this.base64Accum, 'base64'), "utf16-be");
+        res = this.iconv.decode(Buffer.from(this.base64Accum, 'base64'), "utf16-be");
 
     this.inBase64 = false;
     this.base64Accum = '';

--- a/generation/gen-sbcs.js
+++ b/generation/gen-sbcs.js
@@ -1,6 +1,7 @@
 var fs  = require("fs");
 var path = require("path");
 var Iconv  = require("iconv").Iconv;
+var Buffer = require("safer-buffer").Buffer;
 
 // Generate encoding families using original iconv.
 var destFileName = "encodings/sbcs-data-generated.js";
@@ -91,12 +92,12 @@ function generateCharsString(encoding) {
 
     for (var b = 0x0; b < 0x100; b++) {
         try {
-            var convertedChar = iconvToUtf8.convert(new Buffer([b])).toString();
+            var convertedChar = iconvToUtf8.convert(Buffer.from([b])).toString();
             
             if (convertedChar.length != 1)
                 throw new Error("Single-byte encoding error: Must return single char.");
 
-            var convertedBackBuf = iconvFromUtf8.convert(new Buffer(convertedChar));
+            var convertedBackBuf = iconvFromUtf8.convert(Buffer.from(convertedChar));
             if (convertedBackBuf.length != 1)
                 throw new Error("Single-byte encoding error: Cannot decode back.");
 

--- a/generation/research/get-iconv-encodings.js
+++ b/generation/research/get-iconv-encodings.js
@@ -5,6 +5,7 @@
 
 var iconv = require('iconv'),
     crypto = require('crypto');
+var Buffer = require("safer-buffer").Buffer;
 
 
 var skipEncodings = {};
@@ -20,7 +21,7 @@ process.stdin.on("end", function() {
     encodings = input.split(" ").map(function(s) {return s.trim();}).filter(Boolean);
     encodings = encodings.filter(function(enc) {
         try {
-            new iconv.Iconv("utf-8", enc).convert(new Buffer("hello!"));
+            new iconv.Iconv("utf-8", enc).convert(Buffer.from("hello!"));
             if (skipEncodings[enc]) {
                 console.log("Encoding skipped: ", enc);
                 return false;
@@ -38,7 +39,7 @@ process.stdin.on("end", function() {
         process.stderr.write("Checking "+enc+": ");
         var hash = crypto.createHash("sha1");
 
-        var converter = new iconv.Iconv(enc, "utf-8"), buf = new Buffer(10);
+        var converter = new iconv.Iconv(enc, "utf-8"), buf = Buffer.alloc(10);
         var res = {
             enc: [enc],
             isDBCS: true,

--- a/lib/extend-node.js
+++ b/lib/extend-node.js
@@ -1,5 +1,6 @@
 "use strict";
 var Buffer = require("buffer").Buffer;
+// Note: not polyfilled with safer-buffer on a purpose, as overrides Buffer
 
 // == Extend Node primitives to use iconv-lite =================================
 
@@ -8,6 +9,7 @@ module.exports = function (iconv) {
 
     // Node authors rewrote Buffer internals to make it compatible with
     // Uint8Array and we cannot patch key functions since then.
+    // Note: this does use older Buffer API on a purpose
     iconv.supportsNodeEncodingsExtension = !(new Buffer(0) instanceof Uint8Array);
 
     iconv.extendNodeEncodings = function extendNodeEncodings() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 // Some environments don't have global Buffer (e.g. React Native).
 // Solution would be installing npm modules "buffer" and "stream" explicitly.
-var Buffer = require("buffer").Buffer;
+var Buffer = require("safer-buffer").Buffer;
 
 var bomHandling = require("./bom-handling"),
     iconv = module.exports;
@@ -34,7 +34,7 @@ iconv.decode = function decode(buf, encoding, options) {
             iconv.skipDecodeWarning = true;
         }
 
-        buf = new Buffer("" + (buf || ""), "binary"); // Ensure buffer.
+        buf = Buffer.from("" + (buf || ""), "binary"); // Ensure buffer.
     }
 
     var decoder = iconv.getDecoder(encoding, options);

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
         "istanbul": "*",
         "semver": "*",
         "iconv": "*"
+    },
+    "dependencies": {
+        "safer-buffer": "^2.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
         "./streams": false
     },
     "devDependencies": {
-        "mocha": "*",
-        "request": "*",
+        "mocha": "^3.1.0",
+        "request": "~2.81.0",
         "unorm": "*",
         "errto": "*",
         "async": "*",


### PR DESCRIPTION
This also includes a dependnecy on a polyfill targeting older Node.js versions where Buffer.alloc() and Buffer.from() API is not implemented (Node.js < 4.5.0 and some 5.x versions).

Fixes: https://github.com/ashtuchkin/iconv-lite/issues/176

Ref: https://github.com/nodejs/node/issues/19079
Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Ref: https://nodejs.org/api/buffer.html#buffer_class_buffer
Ref: https://github.com/ChALkeR/safer-buffer/blob/master/Porting-Buffer.md

Also, I would suggest to use this the polyfill on 0.4.x branch (so that existing users would receive the fix), but also to release a new 0.5.0 version, dropping `safer-buffer` dependency, outdated Node.js <4.5.0 (or even <6.0.0) support, and `extendNodeEncodings()` functionality (which doesn't work on any actual Node.js versions).