### PR TITLE
Downgrade dev deps to fix build on older Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
         "./streams": false
     },
     "devDependencies": {
-        "mocha": "*",
-        "request": "*",
+        "mocha": "^3.1.0",
+        "request": "~2.81.0",
         "unorm": "*",
         "errto": "*",
         "async": "*",


### PR DESCRIPTION
This eliminates `const` usage which breaks on older Node.js versions present in the test matrix.
    
Downgraded mocha to ^3 and request to ~2.81.