### PR TITLE
Support typed arrays in iconv.decode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,10 @@ iconv.decode = function decode(buf, encoding, options) {
         buf = Buffer.from("" + (buf || ""), "binary"); // Ensure buffer.
     }
 
+    if (!Buffer.isBuffer(buf) && "buffer" in buf && "byteOffset" in buf && "byteLength" in buf) {
+        buf = new Buffer(buf.buffer, buf.byteOffset, buf.byteLength);
+    }
+
     var decoder = iconv.getDecoder(encoding, options);
 
     var res = decoder.write(buf);


### PR DESCRIPTION
This simplifies using browserified iconv-lite as a standalone library in environments without Buffer by also allowing callers to provide a typed array instead of a buffer.

Note that you can't directly access the Buffer shim from outside the iconv-lite browserify bundle by default. Right now (without this change) you would either have to build and load the Buffer shim separately, indirectly access the Buffer shim via the "constructor" property of a buffer object returned from iconv.encode, or make a custom bundle that exports both iconv and Buffer.