### PR TITLE
Don't ship travis config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ generation
 test
 wiki
 coverage
+.travis.yml


### PR DESCRIPTION
Adds `.travis.yml` to `.npmignore` so that the travis config is not published to npm