### PR TITLE
Upgrade request to v. 2.87.0 to avoid Buffer constructor vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "devDependencies": {
         "mocha": "^3.1.0",
-        "request": "~2.81.0",
+        "request": "~2.87.0",
         "unorm": "*",
         "errto": "*",
         "async": "*",


### PR DESCRIPTION
The version of [request](https://www.npmjs.com/package/request) the tests require has a dependency on [stringstream](https://www.npmjs.com/package/stringstream) which uses the deprecated Buffer constructor. This brings request forward 4 minor versions to a version without that vulnerability.