### PR TITLE
Replacing an instace of `new Buffer.from()`

### DIFF
--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -20,7 +20,7 @@ function SBCSCodec(codecOptions, iconv) {
         codecOptions.chars = asciiString + codecOptions.chars;
     }
 
-    this.decodeBuf = new Buffer.from(codecOptions.chars, 'ucs2');
+    this.decodeBuf = Buffer.from(codecOptions.chars, 'ucs2');
     
     // Encoding buffer.
     var encodeBuf = new Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0));

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -23,7 +23,7 @@ function SBCSCodec(codecOptions, iconv) {
     this.decodeBuf = Buffer.from(codecOptions.chars, 'ucs2');
     
     // Encoding buffer.
-    var encodeBuf = new Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0));
+    var encodeBuf = Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0));
 
     for (var i = 0; i < codecOptions.chars.length; i++)
         encodeBuf[codecOptions.chars.charCodeAt(i)] = i;


### PR DESCRIPTION
- I believe this was an oversight from the commit 59314034f2bb1a1d622023d8acfec64961629364.