### PR TITLE
fix: Do not run extensions if they don't resolve

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,11 +141,19 @@ if (nodeVer) {
     // Load streaming support in Node v0.10+
     var nodeVerArr = nodeVer.split(".").map(Number);
     if (nodeVerArr[0] > 0 || nodeVerArr[1] >= 10) {
-        require("./streams")(iconv);
+        var streamsExtension = require("./streams");
+        if (typeof streamsExtension === 'function') {
+          streamsExtension(iconv);
+        }
     }
 
     // Load Node primitive extensions.
-    require("./extend-node")(iconv);
+    
+    var extendNode = require("./extend-node")
+    if (typeof extendNode === 'function') {
+        extendNode(iconv);
+    }
+    
 }
 
 if ("Ā" != "\u0100") {


### PR DESCRIPTION
If we configure Jest with `browser`: true, the test to check if we are in a node process can pass
but extensions can be resolved to undefined because of the `browser` field config in package.json.
This is why an additional check is needed to see if we have correctly resolved streams and extend-node.