### PR TITLE
[dependencies problem] semver is not support Nodejs 4 and below (Solution1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
  sudo: false
  language: node_js
  node_js:
-   - "0.10"
-   - "0.11"
-   - "0.12"
-   - "iojs"
-   - "4"
    - "6"
    - "8"
    - "10"


### PR DESCRIPTION
Hi Alexander @ashtuchkin ,

As your CI problem,
![travis problem](https://user-images.githubusercontent.com/15310014/72716466-ce4c3e80-3ba4-11ea-9fff-06ed8826d1a1.PNG)

I found the problem that causes one of the dependencies was upgraded. 

it is semver https://github.com/npm/node-semver/compare/v6.1.2...master  .

the latest version of semver is supporting nodejs 6 and higher.

hence I removed nodejs 4 and below from .travis.yml

build result
https://travis-ci.org/Tanandara/iconv-lite/builds/639400158

