### PR TITLE
[dependencies problem] semver is not support Nodejs 4 and below (Solution2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "errto": "*",
         "async": "*",
         "istanbul": "*",
-        "semver": "*",
+        "semver": "6.1.2",
         "iconv": "*"
     },
     "dependencies": {


### PR DESCRIPTION
Hi Alexander @ashtuchkin ,

As your CI problem,
![travis problem](https://user-images.githubusercontent.com/15310014/72716466-ce4c3e80-3ba4-11ea-9fff-06ed8826d1a1.PNG)

I found the problem that causes one of the dependencies was upgraded. 

it is semver https://github.com/npm/node-semver/compare/v6.1.2...master  .

the latest version of semver is supporting nodejs 6 and higher.

hence I fixed semver version to 6.1.2

build result
https://travis-ci.org/Tanandara/iconv-lite/builds/639399377