### PR TITLE
convert sbcs codec and some tests

### DIFF
--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -1,72 +1,77 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
 
 // Single-byte codec. Needs a 'chars' string parameter that contains 256 or 128 chars that
-// correspond to encoded bytes (if 128 - then lower half is ASCII). 
+// correspond to encoded bytes (if 128 - then lower half is ASCII).
 
-exports._sbcs = SBCSCodec;
-function SBCSCodec(codecOptions, iconv) {
-    if (!codecOptions)
-        throw new Error("SBCS codec is called without the data.")
-    
-    // Prepare char buffer for decoding.
-    if (!codecOptions.chars || (codecOptions.chars.length !== 128 && codecOptions.chars.length !== 256))
-        throw new Error("Encoding '"+codecOptions.type+"' has incorrect 'chars' (must be of len 128 or 256)");
-    
-    if (codecOptions.chars.length === 128) {
-        var asciiString = "";
-        for (var i = 0; i < 128; i++)
-            asciiString += String.fromCharCode(i);
-        codecOptions.chars = asciiString + codecOptions.chars;
+exports._sbcs = class SBCSCodec {
+    constructor(codecOptions, iconv) {
+        if (!codecOptions)
+            throw new Error("SBCS codec is called without the data.")
+
+        // Prepare char buffer for decoding.
+        if (!codecOptions.chars || (codecOptions.chars.length !== 128 && codecOptions.chars.length !== 256))
+            throw new Error("Encoding '"+codecOptions.type+"' has incorrect 'chars' (must be of len 128 or 256)");
+
+        if (codecOptions.chars.length === 128) {
+            var asciiString = "";
+            for (let i = 0; i < 128; i++)
+                asciiString += String.fromCharCode(i);
+            codecOptions.chars = asciiString + codecOptions.chars;
+        }
+
+        const decodeBuf = new Uint16Array(codecOptions.chars.length);
+
+        for (let i = 0; i < codecOptions.chars.length; i++)
+            decodeBuf[i] = codecOptions.chars.charCodeAt(i);
+
+        this.decodeBuf = decodeBuf;
+
+        // Encoding buffer.
+        const encodeBuf = iconv.backend.allocBytes(65536, iconv.defaultCharSingleByte.charCodeAt(0));
+
+        for (let i = 0; i < codecOptions.chars.length; i++)
+            encodeBuf[codecOptions.chars.charCodeAt(i)] = i;
+
+        this.encodeBuf = encodeBuf;
+    }
+    get encoder() { return SBCSEncoder; }
+    get decoder() { return SBCSDecoder; }
+}
+
+class SBCSEncoder {
+    constructor(opts, codec, backend) {
+        this.backend = backend;
+        this.encodeBuf = codec.encodeBuf;
     }
 
-    this.decodeBuf = Buffer.from(codecOptions.chars, 'ucs2');
-    
-    // Encoding buffer.
-    var encodeBuf = Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0));
+    write(str) {
+        const bytes = this.backend.allocBytes(str.length);
 
-    for (var i = 0; i < codecOptions.chars.length; i++)
-        encodeBuf[codecOptions.chars.charCodeAt(i)] = i;
+        for (let i = 0; i < str.length; i++)
+            bytes[i] = this.encodeBuf[str.charCodeAt(i)];
 
-    this.encodeBuf = encodeBuf;
-}
-
-SBCSCodec.prototype.encoder = SBCSEncoder;
-SBCSCodec.prototype.decoder = SBCSDecoder;
-
-
-function SBCSEncoder(options, codec) {
-    this.encodeBuf = codec.encodeBuf;
-}
-
-SBCSEncoder.prototype.write = function(str) {
-    var buf = Buffer.alloc(str.length);
-    for (var i = 0; i < str.length; i++)
-        buf[i] = this.encodeBuf[str.charCodeAt(i)];
-    
-    return buf;
-}
-
-SBCSEncoder.prototype.end = function() {
-}
-
-
-function SBCSDecoder(options, codec) {
-    this.decodeBuf = codec.decodeBuf;
-}
-
-SBCSDecoder.prototype.write = function(buf) {
-    // Strings are immutable in JS -> we use ucs2 buffer to speed up computations.
-    var decodeBuf = this.decodeBuf;
-    var newBuf = Buffer.alloc(buf.length*2);
-    var idx1 = 0, idx2 = 0;
-    for (var i = 0; i < buf.length; i++) {
-        idx1 = buf[i]*2; idx2 = i*2;
-        newBuf[idx2] = decodeBuf[idx1];
-        newBuf[idx2+1] = decodeBuf[idx1+1];
+        return this.backend.bytesToResult(bytes, bytes.length);
     }
-    return newBuf.toString('ucs2');
+
+    end() {}
 }
 
-SBCSDecoder.prototype.end = function() {
+class SBCSDecoder {
+    constructor(opts, codec, backend) {
+        this.decodeBuf = codec.decodeBuf;
+        this.backend = backend;
+    }
+
+    write(buf) {
+        // Strings are immutable in JS -> we use ucs2 buffer to speed up computations.
+        const decodeBuf = this.decodeBuf;
+        const chars = this.backend.allocRawChars(buf.length);
+
+        for (let i = 0; i < buf.length; i++) {
+            chars[i] = decodeBuf[buf[i]];
+        }
+        return this.backend.rawCharsToResult(chars, chars.length);
+    }
+
+    end() {}
 }

--- a/test/cyrillic-test.js
+++ b/test/cyrillic-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert'),
-    Buffer = require('safer-buffer').Buffer,
-    iconv = require(__dirname+'/../');
+    utils = require('./utils'),
+    iconv = utils.requireIconv();
 
 var baseStrings = {
     empty: "",
@@ -14,66 +14,85 @@ var baseStrings = {
     untranslatable: "£Åçþÿ¿",
 };
 
-var encodings = [{
-    name: "Win-1251",
-    variations: ['win1251', 'Windows-1251', 'windows1251', 'CP1251', 1251],
-    encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\xcf\xf0\xe8\xe2\xe5\xf2!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        rus: Buffer.from('\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff', 'binary'),
-        additional1: Buffer.from('\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf','binary'),
+var encodings = [
+    {
+        name: "Win-1251",
+        variations: ['win1251', 'Windows-1251', 'windows1251', 'CP1251', 1251],
+        encodedStrings: {
+            empty: utils.bytesFrom([]),
+            hi: utils.bytesFrom([0xcf,0xf0,0xe8,0xe2,0xe5,0xf2,0x21]),
+            ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+            rus: utils.bytesFrom([0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xdb,0xdc,0xdd,0xde,0xdf,0xe0,0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff]),
+            additional1: utils.bytesFrom([0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,0x95,0x96,0x97,0x99,0x9a,0x9b,0x9c,0x9d,0x9e,0x9f,0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xbb,0xbc,0xbd,0xbe,0xbf]),
+        }
+    },
+    {
+        name: "Koi8-R",
+        variations: ['koi8r', 'KOI8-R', 'cp20866', 20866],
+        encodedStrings: {
+            empty: utils.bytesFrom([]),
+            hi: utils.bytesFrom([0xf0,0xd2,0xc9,0xd7,0xc5,0xd4,0x21]),
+            ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+            rus: utils.bytesFrom([0xe1,0xe2,0xf7,0xe7,0xe4,0xe5,0xf6,0xfa,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,0xf0,0xf2,0xf3,0xf4,0xf5,0xe6,0xe8,0xe3,0xfe,0xfb,0xfd,0xff,0xf9,0xf8,0xfc,0xe0,0xf1,0xc1,0xc2,0xd7,0xc7,0xc4,0xc5,0xd6,0xda,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd2,0xd3,0xd4,0xd5,0xc6,0xc8,0xc3,0xde,0xdb,0xdd,0xdf,0xd9,0xd8,0xdc,0xc0,0xd1]),
+            additional2: utils.bytesFrom([0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0x9b,0x9c,0x9d,0x9e,0x9f,0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xbb,0xbc,0xbd,0xbe,0xbf]),
+        }
+    },
+    {
+        name: "ISO 8859-5",
+        variations: ['iso88595', 'ISO-8859-5', 'ISO 8859-5', 'cp28595', 28595],
+        encodedStrings: {
+            empty: utils.bytesFrom([]),
+            hi: utils.bytesFrom([0xbf,0xe0,0xd8,0xd2,0xd5,0xe2,0x21]),
+            ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+            rus: utils.bytesFrom([0xb0,0xb1,0xb2,0xb3,0xb4,0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xbb,0xbc,0xbd,0xbe,0xbf,0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xdb,0xdc,0xdd,0xde,0xdf,0xe0,0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef]),
+            additional3: utils.bytesFrom([0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff]),
+        }
     }
-}, {
-    name: "Koi8-R",
-    variations: ['koi8r', 'KOI8-R', 'cp20866', 20866],
-    encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\xf0\xd2\xc9\xd7\xc5\xd4!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        rus: Buffer.from('\xe1\xe2\xf7\xe7\xe4\xe5\xf6\xfa\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf2\xf3\xf4\xf5\xe6\xe8\xe3\xfe\xfb\xfd\xff\xf9\xf8\xfc\xe0\xf1\xc1\xc2\xd7\xc7\xc4\xc5\xd6\xda\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd2\xd3\xd4\xd5\xc6\xc8\xc3\xde\xdb\xdd\xdf\xd9\xd8\xdc\xc0\xd1', 'binary'),
-        additional2: Buffer.from('\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf', 'binary'),
-    }
-}, {
-    name: "ISO 8859-5",
-    variations: ['iso88595', 'ISO-8859-5', 'ISO 8859-5', 'cp28595', 28595],
-    encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\xbf\xe0\xd8\xd2\xd5\xe2!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        rus: Buffer.from('\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef', 'binary'),
-        additional3: Buffer.from('\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff', 'binary'),
-    }
-}];
+];
 
-describe("Test Cyrillic encodings", function() {
+describe("Test Cyrillic encodings #node-web", function() {
     encodings.forEach(function(encoding) {
         var enc = encoding.variations[0];
         var key = "hi";
         describe(encoding.name+":", function() {
-            
+
             it("Convert from buffer", function() {
-                for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc), 
-                        baseStrings[key]);
+                for (const key in encoding.encodedStrings)
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        baseStrings[key]
+                    );
             });
-            
+
             it("Convert to buffer", function() {
-                for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.encode(baseStrings[key], enc).toString('binary'), 
-                        encoding.encodedStrings[key].toString('binary'));
+                for (const key in encoding.encodedStrings)
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(baseStrings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
             });
 
             it("Try different variations of encoding", function() {
                 encoding.variations.forEach(function(enc) {
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc), baseStrings[key]);
-                    assert.strictEqual(iconv.encode(baseStrings[key], enc).toString('binary'), encoding.encodedStrings[key].toString('binary'));
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        baseStrings[key]
+                    );
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(baseStrings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
                 });
             });
 
             it("Untranslatable chars are converted to defaultCharSingleByte", function() {
-                var expected = baseStrings.untranslatable.split('').map(function(c) {return iconv.defaultCharSingleByte; }).join('');
-                assert.strictEqual(iconv.encode(baseStrings.untranslatable, enc).toString('binary'), expected); // Only '?' characters.
+                const untranslatableBytes = utils.bytesFrom(
+                    baseStrings.untranslatable.split('').map(() => iconv.defaultCharSingleByte.charCodeAt(0))
+                );
+                assert.strictEqual(
+                    utils.hex(iconv.encode(baseStrings.untranslatable, enc)),
+                    utils.hex(untranslatableBytes)
+                ); // Only '?' characters.
             });
         });
     });

--- a/test/greek-test.js
+++ b/test/greek-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert'),
-    Buffer = require('safer-buffer').Buffer,
-    iconv = require(__dirname+'/../');
+    utils = require('./utils'),
+    iconv = utils.requireIconv();
 
 var baseStrings = {
     empty: "",
@@ -15,58 +15,73 @@ var encodings = [{
     name: "windows1253",
     variations: ['windows-1253', 'win-1253', 'win1253', 'cp1253', 'cp-1253', 1253],
     encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\xc3\xe5\xe9\xdc!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        greek: Buffer.from('\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xdc\xdd\xde\xdf\xfc\xfd\xfe\xa2\xb8\xb9\xba\xbc\xbe\xbf\xfa\xfb\xda\xdb', 'binary'),
+        empty: utils.bytesFrom([]),
+        hi: utils.bytesFrom([0xc3,0xe5,0xe9,0xdc,0x21]),
+        ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+        greek: utils.bytesFrom([0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,0xf0,0xf1,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xdc,0xdd,0xde,0xdf,0xfc,0xfd,0xfe,0xa2,0xb8,0xb9,0xba,0xbc,0xbe,0xbf,0xfa,0xfb,0xda,0xdb])
     }
 }, {
     name: "iso88597",
     variations: ['iso-8859-7', 'greek', 'greek8', 'cp28597', 'cp-28597', 28597],
     encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\xc3\xe5\xe9\xdc!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        greek: Buffer.from('\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xdc\xdd\xde\xdf\xfc\xfd\xfe\xb6\xb8\xb9\xba\xbc\xbe\xbf\xfa\xfb\xda\xdb', 'binary'),
+        empty: utils.bytesFrom([]),
+        hi: utils.bytesFrom([0xc3,0xe5,0xe9,0xdc,0x21]),
+        ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+        greek: utils.bytesFrom([0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,0xf0,0xf1,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xdc,0xdd,0xde,0xdf,0xfc,0xfd,0xfe,0xb6,0xb8,0xb9,0xba,0xbc,0xbe,0xbf,0xfa,0xfb,0xda,0xdb])
     }
 }, {
     name: "cp737",
     variations: ['cp-737', 737],
     encodedStrings: {
-        empty: Buffer.from(''),
-        hi: Buffer.from('\x82\x9c\xa0\xe1!', 'binary'),
-        ascii: Buffer.from(baseStrings.ascii, 'binary'),
-        greek: Buffer.from('\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xab\xac\xad\xae\xaf\xe0\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\xe1\xe2\xe3\xe5\xe6\xe7\xe9\xea\xeb\xec\xed\xee\xef\xf0\xe4\xe8\xf4\xf5', 'binary'),
+        empty: utils.bytesFrom([]),
+        hi: utils.bytesFrom([0x82,0x9c,0xa0,0xe1,0x21]),
+        ascii: utils.bytesFrom(baseStrings.ascii.split('').map(c => c.charCodeAt(0))),
+        greek: utils.bytesFrom([0x98,0x99,0x9a,0x9b,0x9c,0x9d,0x9e,0x9f,0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xab,0xac,0xad,0xae,0xaf,0xe0,0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,0x95,0x96,0x97,0xe1,0xe2,0xe3,0xe5,0xe6,0xe7,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,0xf0,0xe4,0xe8,0xf4,0xf5])
     }
 }];
 
-describe("Test Greek encodings", function() {
+describe("Test Greek encodings #node-web", function() {
     encodings.forEach(function(encoding) {
         var enc = encoding.variations[0];
         var key = "hi";
         describe(encoding.name+":", function() {
             it("Convert from buffer", function() {
                 for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc), 
-                        baseStrings[key]);
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        baseStrings[key]
+                    );
             });
 
             it("Convert to buffer", function() {
                 for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.encode(baseStrings[key], enc).toString('binary'), 
-                        encoding.encodedStrings[key].toString('binary'));
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(baseStrings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
             });
 
             it("Try different variations of encoding", function() {
                 encoding.variations.forEach(function(enc) {
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc), baseStrings[key]);
-                    assert.strictEqual(iconv.encode(baseStrings[key], enc).toString('binary'), encoding.encodedStrings[key].toString('binary'));
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        baseStrings[key]
+                    );
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(baseStrings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
                 });
             });
 
             it("Untranslatable chars are converted to defaultCharSingleByte", function() {
-                var expected = baseStrings.untranslatable.split('').map(function(c) {return iconv.defaultCharSingleByte; }).join('');
-                assert.strictEqual(iconv.encode(baseStrings.untranslatable, enc).toString('binary'), expected); // Only '?' characters.
+                const untranslatableBytes = utils.bytesFrom(
+                    baseStrings.untranslatable.split('').map(() => iconv.defaultCharSingleByte.charCodeAt(0))
+                );
+                assert.strictEqual(
+                    utils.hex(iconv.encode(baseStrings.untranslatable, enc)),
+                    utils.hex(untranslatableBytes)
+                ); // Only '?' characters.
             });
         })
     });

--- a/test/turkish-test.js
+++ b/test/turkish-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert'),
-    Buffer = require('safer-buffer').Buffer,
-    iconv = require(__dirname+'/../');
+    utils = require('./utils'),
+    iconv = utils.requireIconv();
 
 var ascii = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f'+
            ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f';
@@ -15,18 +15,18 @@ var encodings = [{
         untranslatable: "\x81\x8d\x8e\x8f\x90\x9d\x9e"
     },
     encodedStrings: {
-        empty: Buffer.from(''),
-        ascii: Buffer.from(ascii, 'binary'),
-        turkish: Buffer.from(
-            '\x80\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c' +
-            '\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9f' +
-            '\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xae\xaf' +
-            '\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf' +
-            '\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf' +
-            '\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf' +
-            '\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef' +
-            '\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff',
-            'binary'),
+        empty: utils.bytesFrom([]),
+        ascii: utils.bytesFrom(ascii.split('').map(c => c.charCodeAt(0))),
+        turkish: utils.bytesFrom([
+            0x80,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,
+            0x91,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0x9b,0x9c,0x9f,
+            0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xae,0xaf,
+            0xb0,0xb1,0xb2,0xb3,0xb4,0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xbb,0xbc,0xbd,0xbe,0xbf,
+            0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,
+            0xd0,0xd1,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xdb,0xdc,0xdd,0xde,0xdf,
+            0xe0,0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,
+            0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff
+        ])
     }
 }, {
     name: "iso88599",
@@ -38,46 +38,61 @@ var encodings = [{
         untranslatable: ''
     },
     encodedStrings: {
-        empty: Buffer.from(''),
-        ascii: Buffer.from(ascii, 'binary'),
-        turkish: Buffer.from(
-            '\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf' +
-            '\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf' +
-            '\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf' +
-            '\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf' +
-            '\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef' +
-            '\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff',
-             'binary')
+        empty: utils.bytesFrom([]),
+        ascii: utils.bytesFrom(ascii.split('').map(c => c.charCodeAt(0))),
+        turkish: utils.bytesFrom([
+            0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,
+            0xb0,0xb1,0xb2,0xb3,0xb4,0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xbb,0xbc,0xbd,0xbe,0xbf,
+            0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,
+            0xd0,0xd1,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xdb,0xdc,0xdd,0xde,0xdf,
+            0xe0,0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,
+            0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff
+        ])
     }
 }];
 
-describe("Test Turkish encodings", function() {
+describe("Test Turkish encodings #node-web", function() {
     encodings.forEach(function(encoding) {
         var enc = encoding.variations[0];
         var key = "turkish";
         describe(encoding.name+":", function() {
             it("Convert from buffer", function() {
                 for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc),
-                        encoding.strings[key]);
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        encoding.strings[key]
+                    );
             });
 
             it("Convert to buffer", function() {
                 for (var key in encoding.encodedStrings)
-                    assert.strictEqual(iconv.encode(encoding.strings[key], enc).toString('binary'),
-                        encoding.encodedStrings[key].toString('binary'));
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(encoding.strings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
             });
 
             it("Try different variations of encoding", function() {
                 encoding.variations.forEach(function(enc) {
-                    assert.strictEqual(iconv.decode(encoding.encodedStrings[key], enc), encoding.strings[key]);
-                    assert.strictEqual(iconv.encode(encoding.strings[key], enc).toString('binary'), encoding.encodedStrings[key].toString('binary'));
+                    assert.strictEqual(
+                        iconv.decode(encoding.encodedStrings[key], enc),
+                        encoding.strings[key]
+                    );
+                    assert.strictEqual(
+                        utils.hex(iconv.encode(encoding.strings[key], enc)),
+                        utils.hex(encoding.encodedStrings[key])
+                    );
                 });
             });
 
             it("Untranslatable chars are converted to defaultCharSingleByte", function() {
-                var expected = encoding.strings.untranslatable.split('').map(function(c) {return iconv.defaultCharSingleByte; }).join('');
-                assert.strictEqual(iconv.encode(encoding.strings.untranslatable, enc).toString('binary'), expected); // Only '?' characters.
+                const untranslatableBytes = utils.bytesFrom(
+                    encoding.strings.untranslatable.split('').map(() => iconv.defaultCharSingleByte.charCodeAt(0))
+                );
+                assert.strictEqual(
+                    utils.hex(iconv.encode(encoding.strings.untranslatable, enc)),
+                    utils.hex(untranslatableBytes)
+                ); // Only '?' characters.
             });
         });
     });

--- a/test/webpack/iconv-lite-tests.js
+++ b/test/webpack/iconv-lite-tests.js
@@ -5,3 +5,6 @@ require("../utils").setIconvLite(iconv);
 
 // List of test files that are ready to be run in web environment.
 require("../utf16-test");
+require("../cyrillic-test");
+require("../greek-test");
+require("../turkish-test");


### PR DESCRIPTION
Here is the update for SBCS.

My only problem is - I am not sure how to convert `sbcs-test.js` because it uses `iconv` and I am not sure what to do with some usages of `Buffer` there. Maybe it'd be better for you to take a look at this suite?

Otherwise I think everything is there.