### PR TITLE
Add byteLength method and hasState property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ buf = iconv.encode("Sample input string", "win1251");
 
 // Check if encoding is supported
 iconv.encodingExists("us-ascii");
+
+// Calculate the actual length in bytes.
+len = iconv.byteLength("Hello, world! 😀", "utf16be");
+
+// Get a decoder and decode two different buffers into a single string, the decoder keeps state between buffers
+var utf8Decoder = iconv.getDecoder("utf8");
+var bytes1 = Buffer.from([0x20, 0x23, 0xe2]); // space, # and part of ☣
+var bytes2 = Buffer.from([0x98, 0xa3]); // the rest of ☣
+var str = utf8Decoder.write(bytes1);
+// You can check if the decoder has state currently
+var hasState = utf8Decoder.hasState; // true;
+str += utf8Decoder.write(bytes2);
+var hasState = utf8Decoder.hasState; // false;
+
+// The same for encoder, you rarely need to care about the encoder's state, except for some special encoders and surrogate pair
+var utf8Encoder = iconv.getEncoder("utf8");
+var bytes = utf8Encoder.write("Hi \uD83D");
+var hasState = utf8Encoder.hasState; // true
+bytes = bytes.concat([utf8Encoder.write("\uDE00")]);
+hasState = utf8Encoder.hasState; // false
+
+// Use the "end" method to get the remaining data in encoder/decoder's state and clear the state
+var bytes = encoder.end();
+var str = decoder.end();
 ```
 
 ### Streaming API
@@ -112,9 +136,9 @@ This library supports UTF-32LE, UTF-32BE and UTF-32 encodings. Like the UTF-16 e
 
 ## Other notes
 
-When decoding, be sure to supply a Buffer to decode() method, otherwise [bad things usually happen](https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding).  
-Untranslatable characters are set to � or ?. No transliteration is currently supported.  
-Node versions 0.10.31 and 0.11.13 are buggy, don't use them (see #65, #77).
+-   When decoding, be sure to supply a Buffer to decode() method, otherwise [bad things usually happen](https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding).
+-   Untranslatable characters are set to � or ?. No transliteration is currently supported.
+-   Node versions 0.10.31 and 0.11.13 are buggy, don't use them (see #65, #77).
 
 ## Testing
 

--- a/encodings/dbcs-codec.js
+++ b/encodings/dbcs-codec.js
@@ -439,6 +439,25 @@ class DBCSEncoder {
             else byteLength += 4;
         }
 
+        if (leadSurrogate !== -1 || seqObj !== undefined) {
+            if (seqObj) {
+                // We're in the sequence.
+                const dbcsCode = seqObj[DEF_CHAR];
+                if (dbcsCode !== undefined) {
+                    // Write beginning of the sequence.
+                    if (dbcsCode < 0x100) byteLength++;
+                    else byteLength += 2;
+                } else {
+                    // See todo above.
+                }
+            }
+
+            if (leadSurrogate !== -1) {
+                // Incomplete surrogate pair - only lead surrogate found.
+                byteLength++;
+            }
+        }
+
         return byteLength;
     }
 

--- a/encodings/dbcs-codec.js
+++ b/encodings/dbcs-codec.js
@@ -337,9 +337,9 @@ class DBCSEncoder {
         let leadSurrogate = -1,
             seqObj = undefined,
             nextChar = -1,
-            i = 0,
+            i = 0;
 
-        for (; ;) {
+        for (;;) {
             // 0. Get next character.
             let uCode;
             if (nextChar === -1) {
@@ -421,7 +421,7 @@ class DBCSEncoder {
                     const idx = findIdx(this.gb18030.uChars, uCode);
                     if (idx !== -1) {
                         dbcsCode = this.gb18030.gbChars[idx] + (uCode - this.gb18030.uChars[idx]);
-                        dbcsCode = dbcsCode % 12600 % 1260 % 10;
+                        dbcsCode = ((dbcsCode % 12600) % 1260) % 10;
                         byteLength += 4;
                         continue;
                     }
@@ -433,14 +433,10 @@ class DBCSEncoder {
                 dbcsCode = this.defaultCharSingleByte;
             }
 
-            if (dbcsCode < 0x100)
-                byteLength += 1;
-            else if (dbcsCode < 0x10000)
-                byteLength += 2;
-            else if (dbcsCode < 0x1000000)
-                byteLength += 3;
-            else
-                byteLength += 4;
+            if (dbcsCode < 0x100) byteLength += 1;
+            else if (dbcsCode < 0x10000) byteLength += 2;
+            else if (dbcsCode < 0x1000000) byteLength += 3;
+            else byteLength += 4;
         }
 
         return byteLength;

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -56,11 +56,11 @@ function InternalDecoder(options, codec) {
     this.decoder = new StringDecoder(codec.enc);
 }
 
-Object.defineProperty(InternalDecoder.prototype, 'hasState', {
+Object.defineProperty(InternalDecoder.prototype, "hasState", {
     get: function () {
         // TODO: hopefully this will not be changed in newer version of NodeJS
-        return this.decoder['lastNeed'] !== 0;
-    }
+        return this.decoder["lastNeed"] !== 0;
+    },
 });
 
 InternalDecoder.prototype.write = function (buf) {
@@ -82,15 +82,15 @@ function InternalEncoder(options, codec) {
     this.enc = codec.enc;
 }
 
-Object.defineProperty(InternalEncoder.prototype, 'hasState', {
+Object.defineProperty(InternalEncoder.prototype, "hasState", {
     get: function () {
         return false;
-    }
+    },
 });
 
 InternalEncoder.prototype.byteLength = function (str) {
     return Buffer.byteLength(str, this.enc);
-}
+};
 
 InternalEncoder.prototype.write = function (str) {
     return Buffer.from(str, this.enc);
@@ -105,10 +105,10 @@ function InternalEncoderBase64() {
     this.prevStr = "";
 }
 
-Object.defineProperty(InternalEncoderBase64.prototype, 'hasState', {
+Object.defineProperty(InternalEncoderBase64.prototype, "hasState", {
     get: function () {
         return this.prevStr.length > 0;
-    }
+    },
 });
 
 InternalEncoderBase64.prototype.byteLength = function (str) {
@@ -116,8 +116,8 @@ InternalEncoderBase64.prototype.byteLength = function (str) {
     str = str.slice(0, completeQuads);
     var nonPaddedLength = str.search(/=*$/);
     if (nonPaddedLength === -1) nonPaddedLength = str.length;
-    return Math.floor(nonPaddedLength * 3 / 4);
-}
+    return Math.floor((nonPaddedLength * 3) / 4);
+};
 
 InternalEncoderBase64.prototype.write = function (str) {
     str = this.prevStr + str;
@@ -137,25 +137,22 @@ InternalEncoderBase64.prototype.end = function () {
 
 function InternalEncoderCesu8() {}
 
-Object.defineProperty(InternalEncoderBase64.prototype, 'hasState', {
+Object.defineProperty(InternalEncoderCesu8.prototype, "hasState", {
     get: function () {
         return false;
-    }
+    },
 });
 
 InternalEncoderCesu8.prototype.byteLength = function (str) {
     let byteLength = 0;
     for (let i = 0; i < str.length; i++) {
         const charCode = str.charCodeAt(i);
-        if (charCode < 0x80)
-            byteLength += 1;
-        else if (charCode < 0x800)
-            byteLength += 2;
-        else
-            byteLength += 3;
+        if (charCode < 0x80) byteLength += 1;
+        else if (charCode < 0x800) byteLength += 2;
+        else byteLength += 3;
     }
     return byteLength;
-}
+};
 
 InternalEncoderCesu8.prototype.write = function (str) {
     const buf = Buffer.alloc(str.length * 3);
@@ -191,10 +188,10 @@ function InternalDecoderCesu8(options, codec) {
     this.defaultCharUnicode = codec.defaultCharUnicode;
 }
 
-Object.defineProperty(InternalDecoderCesu8.prototype, 'hasState', {
+Object.defineProperty(InternalDecoderCesu8.prototype, "hasState", {
     get: function () {
         return this.contBytes > 0;
-    }
+    },
 });
 
 InternalDecoderCesu8.prototype.write = function (buf) {

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -56,6 +56,13 @@ function InternalDecoder(options, codec) {
     this.decoder = new StringDecoder(codec.enc);
 }
 
+Object.defineProperty(InternalDecoder.prototype, 'hasState', {
+    get: function () {
+        // TODO: hopefully this will not be changed in newer version of NodeJS
+        return this.decoder['lastNeed'] !== 0;
+    }
+});
+
 InternalDecoder.prototype.write = function (buf) {
     if (!Buffer.isBuffer(buf)) {
         buf = Buffer.from(buf);
@@ -75,6 +82,16 @@ function InternalEncoder(options, codec) {
     this.enc = codec.enc;
 }
 
+Object.defineProperty(InternalEncoder.prototype, 'hasState', {
+    get: function () {
+        return false;
+    }
+});
+
+InternalEncoder.prototype.byteLength = function (str) {
+    return Buffer.byteLength(str, this.enc);
+}
+
 InternalEncoder.prototype.write = function (str) {
     return Buffer.from(str, this.enc);
 };
@@ -86,6 +103,20 @@ InternalEncoder.prototype.end = function () {};
 
 function InternalEncoderBase64() {
     this.prevStr = "";
+}
+
+Object.defineProperty(InternalEncoderBase64.prototype, 'hasState', {
+    get: function () {
+        return this.prevStr.length > 0;
+    }
+});
+
+InternalEncoderBase64.prototype.byteLength = function (str) {
+    var completeQuads = str.length - (str.length % 4);
+    str = str.slice(0, completeQuads);
+    var nonPaddedLength = str.search(/=*$/);
+    if (nonPaddedLength === -1) nonPaddedLength = str.length;
+    return Math.floor(nonPaddedLength * 3 / 4);
 }
 
 InternalEncoderBase64.prototype.write = function (str) {
@@ -105,6 +136,26 @@ InternalEncoderBase64.prototype.end = function () {
 // CESU-8 encoder is also special.
 
 function InternalEncoderCesu8() {}
+
+Object.defineProperty(InternalEncoderBase64.prototype, 'hasState', {
+    get: function () {
+        return false;
+    }
+});
+
+InternalEncoderCesu8.prototype.byteLength = function (str) {
+    let byteLength = 0;
+    for (let i = 0; i < str.length; i++) {
+        const charCode = str.charCodeAt(i);
+        if (charCode < 0x80)
+            byteLength += 1;
+        else if (charCode < 0x800)
+            byteLength += 2;
+        else
+            byteLength += 3;
+    }
+    return byteLength;
+}
 
 InternalEncoderCesu8.prototype.write = function (str) {
     const buf = Buffer.alloc(str.length * 3);
@@ -139,6 +190,12 @@ function InternalDecoderCesu8(options, codec) {
     this.accBytes = 0;
     this.defaultCharUnicode = codec.defaultCharUnicode;
 }
+
+Object.defineProperty(InternalDecoderCesu8.prototype, 'hasState', {
+    get: function () {
+        return this.contBytes > 0;
+    }
+});
 
 InternalDecoderCesu8.prototype.write = function (buf) {
     let acc = this.acc,

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -112,11 +112,17 @@ Object.defineProperty(InternalEncoderBase64.prototype, "hasState", {
 });
 
 InternalEncoderBase64.prototype.byteLength = function (str) {
+    var byteLength = 0;
     var completeQuads = str.length - (str.length % 4);
+    var prevStr = str.slice(completeQuads);
     str = str.slice(0, completeQuads);
     var nonPaddedLength = str.search(/=*$/);
     if (nonPaddedLength === -1) nonPaddedLength = str.length;
-    return Math.floor((nonPaddedLength * 3) / 4);
+    byteLength += Math.floor((nonPaddedLength * 3) / 4);
+    nonPaddedLength = prevStr.search(/=*$/);
+    if (nonPaddedLength === -1) nonPaddedLength = str.length;
+    byteLength += Math.floor((nonPaddedLength * 3) / 4);
+    return byteLength;
 };
 
 InternalEncoderBase64.prototype.write = function (str) {

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -58,6 +58,12 @@ class SBCSEncoder {
         this.encodeBuf = codec.encodeBuf;
     }
 
+    byteLength(str) {
+        return str.length;
+    }
+
+    get hasState() { return false; }
+
     write(str) {
         const bytes = this.backend.allocBytes(str.length);
 
@@ -68,7 +74,7 @@ class SBCSEncoder {
         return this.backend.bytesToResult(bytes, bytes.length);
     }
 
-    end() {}
+    end() { }
 }
 
 class SBCSDecoder {
@@ -76,6 +82,8 @@ class SBCSDecoder {
         this.decodeBuf = codec.decodeBuf;
         this.backend = backend;
     }
+
+    get hasState() { return false; }
 
     write(buf) {
         // Strings are immutable in JS -> we use ucs2 buffer to speed up computations.
@@ -88,5 +96,5 @@ class SBCSDecoder {
         return this.backend.rawCharsToResult(chars, chars.length);
     }
 
-    end() {}
+    end() { }
 }

--- a/encodings/utf16.js
+++ b/encodings/utf16.js
@@ -22,6 +22,12 @@ class Utf16LEEncoder {
         this.backend = backend;
     }
 
+    byteLength(str) {
+        return str.length * 2;
+    }
+
+    get hasState() { return false; }
+
     write(str) {
         const bytes = this.backend.allocBytes(str.length * 2);
         const chars = new Uint16Array(bytes.buffer, bytes.byteOffset, str.length);
@@ -31,7 +37,7 @@ class Utf16LEEncoder {
         return this.backend.bytesToResult(bytes, bytes.length);
     }
 
-    end() {}
+    end() { }
 }
 
 class Utf16LEDecoder {
@@ -40,6 +46,10 @@ class Utf16LEDecoder {
         this.defaultChar = defaultChar;
         this.leadByte = -1;
         this.leadSurrogate = undefined;
+    }
+
+    get hasState() {
+        return this.leadSurrogate || this.leadByte !== -1;
     }
 
     write(buf) {
@@ -158,6 +168,12 @@ class Utf16BEEncoder {
         this.backend = backend;
     }
 
+    byteLength(str) {
+        return str.length * 2;
+    }
+
+    get hasState() { return false; }
+
     write(str) {
         const bytes = this.backend.allocBytes(str.length * 2);
         let bytesPos = 0;
@@ -169,7 +185,7 @@ class Utf16BEEncoder {
         return this.backend.bytesToResult(bytes, bytesPos);
     }
 
-    end() {}
+    end() { }
 }
 
 class Utf16BEDecoder {
@@ -178,6 +194,10 @@ class Utf16BEDecoder {
         this.defaultChar = defaultChar;
         this.leadByte = -1;
         this.leadSurrogate = undefined;
+    }
+
+    get hasState() {
+        return this.leadSurrogate || this.leadByte !== -1;
     }
 
     write(buf) {
@@ -290,6 +310,10 @@ class Utf16Decoder {
 
         this.options = options || {};
         this.iconv = iconv;
+    }
+
+    get hasState() {
+        return this.initialBufsLen !== 0 || (this.decoder != null && this.decoder.hasState);
     }
 
     write(buf) {

--- a/encodings/utf32.js
+++ b/encodings/utf32.js
@@ -29,10 +29,10 @@ function Utf32Encoder(options, codec) {
     this.highSurrogate = 0;
 }
 
-Object.defineProperty(Utf32Encoder.prototype, 'hasState', {
+Object.defineProperty(Utf32Encoder.prototype, "hasState", {
     get: function () {
         return !!this.highSurrogate;
-    }
+    },
 });
 
 Utf32Encoder.prototype.write = function (str) {
@@ -110,7 +110,7 @@ Utf32Encoder.prototype.byteLength = function (str) {
     }
 
     return byteLength;
-}
+};
 
 Utf32Encoder.prototype.end = function () {
     // Treat any leftover high surrogate as a semi-valid independent character.
@@ -136,10 +136,10 @@ function Utf32Decoder(options, codec) {
     this.overflow = [];
 }
 
-Object.defineProperty(Utf32Encoder.prototype, 'hasState', {
+Object.defineProperty(Utf32Decoder.prototype, "hasState", {
     get: function () {
         return this.overflow.length > 0;
-    }
+    },
 });
 
 Utf32Decoder.prototype.write = function (src) {
@@ -254,15 +254,15 @@ function Utf32AutoEncoder(options, codec) {
     this.encoder = codec.iconv.getEncoder(options.defaultEncoding || "utf-32le", options);
 }
 
-Object.defineProperty(Utf32Encoder.prototype, 'hasState', {
+Object.defineProperty(Utf32AutoEncoder.prototype, "hasState", {
     get: function () {
         return this.encoder.hasState;
-    }
+    },
 });
 
 Utf32AutoEncoder.prototype.byteLength = function (str) {
     return this.encoder.byteLength(str);
-}
+};
 
 Utf32AutoEncoder.prototype.write = function (str) {
     return this.encoder.write(str);
@@ -282,10 +282,10 @@ function Utf32AutoDecoder(options, codec) {
     this.iconv = codec.iconv;
 }
 
-Object.defineProperty(Utf32Encoder.prototype, 'hasState', {
+Object.defineProperty(Utf32AutoDecoder.prototype, "hasState", {
     get: function () {
         return this.initialBufsLen !== 0 || (this.decoder != null && this.decoder.hasState);
-    }
+    },
 });
 
 Utf32AutoDecoder.prototype.write = function (buf) {

--- a/encodings/utf32.js
+++ b/encodings/utf32.js
@@ -109,6 +109,10 @@ Utf32Encoder.prototype.byteLength = function (str) {
         }
     }
 
+    if (currentHighSurrogate) {
+        byteLength += 4;
+    }
+
     return byteLength;
 };
 

--- a/encodings/utf7.js
+++ b/encodings/utf7.js
@@ -180,7 +180,7 @@ function Utf7IMAPEncoder(options, codec) {
     this.base64AccumIdx = 0;
 }
 
-Utf7Encoder.prototype.byteLength = function (str) {
+Utf7IMAPEncoder.prototype.byteLength = function (str) {
     var byteLength = 0;
     var inBase64 = false,
         base64AccumLength = 0;
@@ -217,6 +217,12 @@ Utf7Encoder.prototype.byteLength = function (str) {
                 }
             }
         }
+    }
+    if (inBase64) {
+        if (base64AccumLength > 0) {
+            byteLength += Math.ceil((base64AccumLength * 4) / 3); // without padding
+        }
+        byteLength++; // Count '-', then go to direct mode.
     }
 
     return byteLength;

--- a/lib/bom-handling.js
+++ b/lib/bom-handling.js
@@ -8,6 +8,17 @@ exports.PrependBOM = class PrependBOMWrapper {
         this.addBOM = true;
     }
 
+    get hasState() {
+        return this.encoder.hasState;
+    }
+
+    byteLength(str) {
+        var byteLength = 0;
+        if (this.addBOM) str = BOMChar + str;
+        byteLength += this.encoder.byteLength(str);
+        return byteLength;
+    }
+
     write(str) {
         if (this.addBOM) {
             str = BOMChar + str;
@@ -26,6 +37,10 @@ exports.StripBOM = class StripBOMWrapper {
         this.decoder = decoder;
         this.pass = false;
         this.options = options || {};
+    }
+
+    get hasState() {
+        return this.decoder.hasState;
     }
 
     write(buf) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,7 +13,7 @@ declare module "iconv-lite" {
 
     export function encodingExists(encoding: string): boolean;
 
-    export function byteLength(content: string, encoding: string): number;
+    export function byteLength(content: string, encoding: string, options?: Options): number;
 
     // Stream API
     export function decodeStream(encoding: string, options?: Options): NodeJS.ReadWriteStream;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,6 +13,8 @@ declare module "iconv-lite" {
 
     export function encodingExists(encoding: string): boolean;
 
+    export function byteLength(content: string, encoding: string): number;
+
     // Stream API
     export function decodeStream(encoding: string, options?: Options): NodeJS.ReadWriteStream;
 
@@ -31,11 +33,14 @@ export interface Options {
 }
 
 export interface EncoderStream {
+    byteLength(str: string): number;
     write(str: string): Buffer;
     end(): Buffer | undefined;
+    hasState: boolean;
 }
 
 export interface DecoderStream {
     write(buf: Buffer): string;
     end(): string | undefined;
+    hasState: boolean;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,10 @@ iconv.getDecoder = function getDecoder(encoding, options) {
     return decoder;
 };
 
+iconv.byteLength = function byteLength(str, encoding) {
+    return iconv.getEncoder(encoding).byteLength(str)
+}
+
 // Streaming API
 // NOTE: Streaming API naturally depends on 'stream' module from Node.js. Unfortunately in browser environments this module can add
 // up to 100Kb to the output bundle. To avoid unnecessary code bloat, we don't enable Streaming API in browser by default.

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,9 +132,9 @@ iconv.getDecoder = function getDecoder(encoding, options) {
     return decoder;
 };
 
-iconv.byteLength = function byteLength(str, encoding) {
-    return iconv.getEncoder(encoding).byteLength(str)
-}
+iconv.byteLength = function byteLength(str, encoding, options) {
+    return iconv.getEncoder(encoding, options).byteLength(str);
+};
 
 // Streaming API
 // NOTE: Streaming API naturally depends on 'stream' module from Node.js. Unfortunately in browser environments this module can add

--- a/test/big5-test.js
+++ b/test/big5-test.js
@@ -65,4 +65,8 @@ describe("Big5 tests #node-web", function () {
     it("Big5 correctly encodes 十", function () {
         assert.strictEqual(utils.hex(iconv.encode("十", "big5")), "a4 51");
     });
+
+    it("Big5 byteLength works correctly", utils.checkByteLength("Big5"));
+
+    it("cp950 byteLength works correctly", utils.checkByteLength("cp950"));
 });

--- a/test/bom-test.js
+++ b/test/bom-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require("assert"),
+    utils = require("./utils"),
     Buffer = require("safer-buffer").Buffer,
     iconv = require("../");
 
@@ -89,4 +90,25 @@ describe("BOM Handling", function () {
         assert.equal(iconv.decode(body2, "utf8", { stripBOM: stripBOM }), sampleStr);
         assert(!bomStripped);
     });
+
+    it("UTF-7 BOM byteLength works correctly", utils.checkByteLength("utf7", { addBOM: true }));
+
+    it("UTF-8 BOM byteLength works correctly", utils.checkByteLength("utf8", { addBOM: true }));
+
+    it(
+        "utf16le BOM byteLength works correctly",
+        utils.checkByteLength("utf16le", { addBOM: true })
+    );
+
+    it(
+        "utf16be BOM byteLength works correctly",
+        utils.checkByteLength("utf16be", { addBOM: true })
+    );
+
+    it("utf16 BOM byteLength works correctly", utils.checkByteLength("utf16", { addBOM: true }));
+
+    it(
+        "utf16 NO BOM byteLength works correctly",
+        utils.checkByteLength("utf16", { addBOM: false })
+    );
 });

--- a/test/cesu8-test.js
+++ b/test/cesu8-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert"),
+    utils = require("./utils"),
     Buffer = require("safer-buffer").Buffer,
     iconv = require("../");
 
@@ -23,4 +24,5 @@ describe("CESU-8 codec", function () {
         assert.equal(iconv.decode(Buffer.from("eda081edb080", "hex"), "cesu8"), "𐐀");
         assert.equal(iconv.decode(Buffer.from("eda0bdedb8b1", "hex"), "cesu8"), "😱");
     });
+    it("CESU-8 byteLength works correctly", utils.checkByteLength("cesu8"));
 });

--- a/test/cyrillic-test.js
+++ b/test/cyrillic-test.js
@@ -110,6 +110,8 @@ describe("Test Cyrillic encodings #node-web", function () {
                     utils.hex(untranslatableBytes)
                 ); // Only '?' characters.
             });
+
+            it(enc + " byteLength works correctly", utils.checkByteLength(enc));
         });
     });
 });

--- a/test/gbk-test.js
+++ b/test/gbk-test.js
@@ -135,4 +135,10 @@ describe("GBK tests #node-web", function () {
         assert.strictEqual(iconv.decode(gbkChars, "GB18030"), chars);
         assert.strictEqual(utils.hex(iconv.encode(chars, "GB18030")), utils.hex(gbkChars));
     });
+
+    it("GBK byteLength works correctly", utils.checkByteLength("GBK"));
+
+    it("GB2312 byteLength works correctly", utils.checkByteLength("GB2312"));
+
+    it("GB18030 byteLength works correctly", utils.checkByteLength("GB18030"));
 });

--- a/test/greek-test.js
+++ b/test/greek-test.js
@@ -98,6 +98,8 @@ describe("Test Greek encodings #node-web", function () {
                     utils.hex(untranslatableBytes)
                 ); // Only '?' characters.
             });
+
+            it(enc + " byteLength works correctly", utils.checkByteLength(enc));
         });
     });
 });

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert"),
+    utils = require("./utils"),
     Buffer = require("safer-buffer").Buffer,
     iconv = require("../");
 
@@ -27,6 +28,13 @@ describe("Generic UTF8-UCS2 tests", function () {
         });
     });
 
+    it("UCS2 byteLength works correctly", utils.checkByteLength("UCS2", null, testStringLatin1));
+
+    it(
+        "binary byteLength works correctly",
+        utils.checkByteLength("binary", null, testStringLatin1)
+    );
+
     it("Base64 correctly encoded/decoded", function () {
         assert.strictEqual(iconv.encode(testStringBase64, "base64").toString("binary"), testString);
         assert.strictEqual(
@@ -35,10 +43,17 @@ describe("Generic UTF8-UCS2 tests", function () {
         );
     });
 
+    it(
+        "Base64 byteLength works correctly",
+        utils.checkByteLength("base64", null, testStringBase64)
+    );
+
     it("Hex correctly encoded/decoded", function () {
         assert.strictEqual(iconv.encode(testStringHex, "hex").toString("binary"), testString);
         assert.strictEqual(iconv.decode(Buffer.from(testString, "binary"), "hex"), testStringHex);
     });
+
+    it("Hex byteLength works correctly", utils.checkByteLength("hex", null, testStringHex));
 
     it("Latin1 correctly encoded/decoded", function () {
         assert.strictEqual(
@@ -50,6 +65,11 @@ describe("Generic UTF8-UCS2 tests", function () {
             testStringLatin1
         );
     });
+
+    it(
+        "Latin1 byteLength works correctly",
+        utils.checkByteLength("Latin1", null, testStringLatin1)
+    );
 
     it("Convert to string, not buffer (utf8 used)", function () {
         assert.throws(function () {

--- a/test/sbcs-test.js
+++ b/test/sbcs-test.js
@@ -179,6 +179,8 @@ describe("Full SBCS encoding tests #node-web", function () {
                     }
                 });
 
+                it(enc + " byteLength works correctly", utils.checkByteLength(enc));
+
                 /*
             // TODO: Implement unicode composition. After that, this test will be meaningful.
 

--- a/test/shiftjis-test.js
+++ b/test/shiftjis-test.js
@@ -42,4 +42,6 @@ describe("ShiftJIS tests #node-web", function () {
         assert.strictEqual(iconv.decode(utils.bytes("87 40"), "shiftjis"), "①");
         assert.strictEqual(utils.hex(iconv.encode("①", "shiftjis")), "87 40");
     });
+
+    it("shiftjis byteLength works correctly", utils.checkByteLength("shiftjis"));
 });

--- a/test/turkish-test.js
+++ b/test/turkish-test.js
@@ -97,6 +97,8 @@ describe("Test Turkish encodings #node-web", function () {
                     utils.hex(untranslatableBytes)
                 ); // Only '?' characters.
             });
+
+            it(enc + " byteLength works correctly", utils.checkByteLength(enc));
         });
     });
 });

--- a/test/utf16-test.js
+++ b/test/utf16-test.js
@@ -54,6 +54,8 @@ describe("UTF-16LE encoder #node-web", function () {
         assert.equal(hex(encoder.write("\uDCA9")), "a9 dc");
         assert.strictEqual(encoder.end(), undefined);
     });
+
+    it("byteLength works correctly", utils.checkByteLength(enc));
 });
 
 describe("UTF-16LE decoder #node-web", function () {
@@ -178,6 +180,8 @@ describe("UTF-16BE encoder #node-web", function () {
         assert.equal(hex(encoder.write("\uDCA9")), "dc a9");
         assert.strictEqual(encoder.end(), undefined);
     });
+
+    it("byteLength works correctly", utils.checkByteLength(enc));
 });
 
 describe("UTF-16BE decoder #node-web", function () {
@@ -261,6 +265,8 @@ describe("UTF-16 encoder #node-web", function () {
     it("can skip BOM", function () {
         assert.equal(hex(iconv.encode(testStr, enc, { addBOM: false })), hex(utf16leBuf));
     });
+
+    it("byteLength works correctly", utils.checkByteLength(enc));
 });
 
 describe("UTF-16 decoder #node-web", function () {

--- a/test/utf32-test.js
+++ b/test/utf32-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert"),
+    utils = require("./utils"),
     Buffer = require("safer-buffer").Buffer,
     iconv = require("../"),
     Iconv = require("iconv").Iconv;
@@ -8,8 +9,8 @@ var assert = require("assert"),
 // prettier-ignore
 var testStr = "1aя中文☃💩",
     testStr2 = "❝Stray high \uD977😱 and low\uDDDD☔ surrogate values.❞",
-    utf32leBuf = Buffer.from([ 0x31, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x4f, 0x04, 0x00, 0x00, 0x2d, 0x4e, 0x00, 0x00, 0x87, 0x65, 0x00, 0x00, 0x03, 0x26, 0x00, 0x00, 0xa9, 0xf4, 0x01, 0x00 ]),
-    utf32beBuf = Buffer.from([ 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x04, 0x4f, 0x00, 0x00, 0x4e, 0x2d, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x26, 0x03, 0x00, 0x01, 0xf4, 0xa9 ]),
+    utf32leBuf = Buffer.from([0x31, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x4f, 0x04, 0x00, 0x00, 0x2d, 0x4e, 0x00, 0x00, 0x87, 0x65, 0x00, 0x00, 0x03, 0x26, 0x00, 0x00, 0xa9, 0xf4, 0x01, 0x00]),
+    utf32beBuf = Buffer.from([0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x04, 0x4f, 0x00, 0x00, 0x4e, 0x2d, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x26, 0x03, 0x00, 0x01, 0xf4, 0xa9]),
     utf32leBOM = Buffer.from([0xff, 0xfe, 0x00, 0x00]),
     utf32beBOM = Buffer.from([0x00, 0x00, 0xfe, 0xff]),
     utf32leBufWithBOM = Buffer.concat([utf32leBOM, utf32leBuf]),
@@ -81,6 +82,8 @@ describe("UTF-32LE codec", function () {
         var nodeStr = nodeIconv.convert(allCharsLEBuf).toString("utf8");
         assert.equal(nodeStr, allCharsStr);
     });
+
+    it("byteLength works correctly", utils.checkByteLength("UTF-32LE"));
 });
 
 describe("UTF-32BE codec", function () {
@@ -118,6 +121,8 @@ describe("UTF-32BE codec", function () {
         var nodeStr = nodeIconv.convert(allCharsBEBuf).toString("utf8");
         assert.equal(nodeStr, allCharsStr);
     });
+
+    it("byteLength works correctly", utils.checkByteLength("UTF-32BE"));
 });
 
 describe("UTF-32 general codec", function () {
@@ -155,6 +160,8 @@ describe("UTF-32 general codec", function () {
     it("correctly decodes UTF-32BE without BOM", function () {
         assert.equal(iconv.decode(iconv.encode(sampleStr, "utf-32-be"), "utf-32"), sampleStr);
     });
+
+    it("byteLength works correctly", utils.checkByteLength("UTF-32"));
 });
 
 // Utility function to make bad matches easier to visualize.
@@ -165,7 +172,7 @@ function escape(s) {
         var cc = s.charCodeAt(i);
 
         // prettier-ignore
-        if ((32 <= cc && cc < 127) && cc !== 0x5c) {  
+        if ((32 <= cc && cc < 127) && cc !== 0x5c) {
             sb.push(s.charAt(i));
         } else {
             var h = s.charCodeAt(i).toString(16).toUpperCase();

--- a/test/utf7-test.js
+++ b/test/utf7-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert"),
+    utils = require("./utils"),
     Buffer = require("safer-buffer").Buffer,
     iconv = require("../");
 
@@ -137,6 +138,8 @@ describe("UTF-7 codec", function () {
         assert.equal(iconv.decode(Buffer.from("+AMAA4A-Next"), "utf-7"), "\u00c0\u00e0Next");
         assert.equal(iconv.decode(Buffer.from("+AMAA4A!Next"), "utf-7"), "\u00c0\u00e0!Next");
     });
+
+    it("byteLength works correctly", utils.checkByteLength("utf-7"));
 });
 
 describe("UTF-7-IMAP codec", function () {
@@ -220,4 +223,6 @@ describe("UTF-7-IMAP codec", function () {
             "\u00E4&\u00E4&\u00E4"
         );
     });
+
+    it("byteLength works correctly", utils.checkByteLength("utf-7-imap"));
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -253,4 +253,23 @@ const utils = (module.exports = {
         }
         assert.equal(i, str.length);
     },
+
+    checkByteLength(encoding, options) {
+        return () => {
+            utils.requireIconv();
+            [
+                "Hello😀world!",
+                "😊 Good bye 😊",
+                "Missing surrogate character \uD83D",
+                "中文abc",
+                "iconv-liteへようこそ",
+                "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
+                "αβγδεζηθικλμνξοπρστυφχψωΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩάέήίόύώΆΈΉΊΌΎΏϊϋΪΫ",
+            ].forEach((content) => {
+                const actual = utils.iconv.byteLength(content, encoding, options);
+                const expect = utils.iconv.encode(content, encoding, options).length;
+                assert.equal(actual, expect);
+            });
+        };
+    },
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -254,18 +254,21 @@ const utils = (module.exports = {
         assert.equal(i, str.length);
     },
 
-    checkByteLength(encoding, options) {
+    checkByteLength(encoding, options, _content) {
         return () => {
             utils.requireIconv();
-            [
-                "Hello😀world!",
-                "😊 Good bye 😊",
-                "Missing surrogate character \uD83D",
-                "中文abc",
-                "iconv-liteへようこそ",
-                "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
-                "αβγδεζηθικλμνξοπρστυφχψωΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩάέήίόύώΆΈΉΊΌΎΏϊϋΪΫ",
-            ].forEach((content) => {
+            (_content
+                ? [_content]
+                : [
+                      "Hello😀world!",
+                      "😊 Good bye 😊",
+                      "Missing surrogate character \uD83D",
+                      "中文abc",
+                      "iconv-liteへようこそ",
+                      "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
+                      "αβγδεζηθικλμνξοπρστυφχψωΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩάέήίόύώΆΈΉΊΌΎΏϊϋΪΫ",
+                  ]
+            ).forEach((content) => {
                 const actual = utils.iconv.byteLength(content, encoding, options);
                 const expect = utils.iconv.encode(content, encoding, options).length;
                 assert.equal(actual, expect);


### PR DESCRIPTION
I would like to add the **byteLength** method and the **hasState** property.

**byteLength method:**
* Guaranteed to be faster than _iconv.encode(..).length_ because it doesn't allocate an entire buffer.
* Usecase: you might have a very long string and don't want to create a very long buffer to encode it, but you want to write that string into a binary file with a prefix byte length (maybe in 7-bit format [likes this method in .NET](https://docs.microsoft.com/en-us/dotnet/api/system.io.binarywriter.write?view=netcore-3.1#System_IO_BinaryWriter_Write_System_String_)). So you can use this method, then you encode the string gradually on its' substrings by an encoder.

**hasState property:**
* If reading binary data to decode, or encoding to write to binary file, you might want know if the decoder or encoder has any accumulated state inside them so you can decide if there is an error or not.