### PR TITLE
Add no-buffer-constructor eslint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,7 @@ rules:
     block-scoped-var: "error"
     prefer-const: "error"
     yoda: ["error", "never", { "exceptRange": true }]
+    no-buffer-constructor: "error"
 
     # 'es' pluin rules. See https://mysticatea.github.io/eslint-plugin-es/rules/
     # Disallow the ones that are not supported by Node 4.5


### PR DESCRIPTION
Now that we've dropped safer-buffer package, let's add a linter rule to avoid breakage in the future, 
as recommended by https://github.com/ChALkeR/safer-buffer/blob/master/Porting-Buffer.md#variant-1