### PR TITLE
Remove safer-buffer

### DIFF
--- a/encodings/dbcs-codec.js
+++ b/encodings/dbcs-codec.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // Multibyte codec. In this scheme, a character is represented by 1 or more bytes.
 // Our codec supports UTF-16 surrogates, extensions for GB18030 and unicode sequences.

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // Export Node.js internal encodings.
 

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // Single-byte codec. Needs a 'chars' string parameter that contains 256 or 128 chars that
 // correspond to encoded bytes (if 128 - then lower half is ASCII). 

--- a/encodings/utf16.js
+++ b/encodings/utf16.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // Note: UTF16-LE (or UCS2) codec is Node.js native. See encodings/internal.js
 

--- a/encodings/utf7.js
+++ b/encodings/utf7.js
@@ -1,5 +1,5 @@
 "use strict";
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // UTF-7 codec, according to https://tools.ietf.org/html/rfc2152
 // See also below a UTF-7-IMAP codec, according to http://tools.ietf.org/html/rfc3501#section-5.1.3

--- a/generation/gen-sbcs.js
+++ b/generation/gen-sbcs.js
@@ -1,7 +1,7 @@
 var fs  = require("fs");
 var path = require("path");
 var Iconv  = require("iconv").Iconv;
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // Generate encoding families using original iconv.
 var destFileName = "encodings/sbcs-data-generated.js";

--- a/generation/research/get-iconv-encodings.js
+++ b/generation/research/get-iconv-encodings.js
@@ -5,7 +5,7 @@
 
 var iconv = require('iconv'),
     crypto = require('crypto');
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 
 var skipEncodings = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 var bomHandling = require("./bom-handling"),
     iconv = module.exports;

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Buffer = require("safer-buffer").Buffer;
+const {Buffer} = require("buffer");
 
 // NOTE: Due to 'stream' module being pretty large (~100Kb, significant in browser environments), 
 // we opt to dependency-inject it instead of creating a hard dependency.

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
         "request": "^2.88.2",
         "semver": "^6.3.0",
         "unorm": "^1.6.0"
-    },
-    "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
     }
 }


### PR DESCRIPTION
Using built in `node:buffer` instead

safe-buffer is definitely not needed when targeting node 6+