### PR TITLE
feat: Add user callback for handling invalid characters.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,9 @@ iconv.decode = function decode(buf, encoding, options) {
     var res = decoder.write(buf);
     var trail = decoder.end();
 
-    return trail ? (res + trail) : res;
+    var res = trail ? (res + trail) : res;
+    if (res.indexOf('�') !== -1 && options && options.invalidCharHandler) res = options.invalidCharHandler()
+    return res
 }
 
 iconv.encodingExists = function encodingExists(enc) {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -7,6 +7,20 @@ var testStringLatin1 = "Hello123!£Å÷×çþÿ¿®";
 var testStringBase64 = "SGVsbG8xMjMh";
 var testStringHex = "48656c6c6f31323321";
 
+describe("user callback", function () {
+    it("Return nothing for issue#210#83", function () {
+        // when bad characters, return nothing instead of the ?.
+        // Like these:
+        // iconv.decode(Buffer.from([128]), 'utf8')
+        // iconv.decode(iconv.encode('ça va','utf8'), 'utf7')
+        assert.strictEqual(iconv.decode(Buffer.from([128]), 'utf8', {
+            invalidCharHandler: function () {
+                return ''
+            }
+        }), '');
+    })
+})
+
 describe("Generic UTF8-UCS2 tests", function() {
     
     it("Return values are of correct types", function() {


### PR DESCRIPTION
hi buddy,this is work-in progress.
It might not be easy to get the user to write a callback function, but I think we can at least do it first.

I have noticed that there are many issues about callback(#53)  at present,
It may be difficult to solve all the problems, but we can take them apart step by step,
So now I have taken the first step (at least we can solve #210  for now),
and the first step now seems easy(or too easy🤣).

First, we declare and tell the user what custom rules can be processed:
```js
iconv.invalidChar;
iconv.ignore = '';
// ...other rules
// Sorry, I don't know how to describe it here, maybe TS would be better
```
Then, the options argument can be passed in when the user calls public API, like:
```js
iconv.decode(Buffer, encoding,{
  invalidChar: function(){/**/},
  ignore: someRules,
  // ...other rules
})
```
Finally, we pick it up at decode:
```js
iconv.decode = function decode(buf, encoding, options) {
// ...
if(options && options.invalidChar)  // ...
// ...
}
```
and the encoding is written similarly.

In short, we accept some special rules that user-written callback functions.

