### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bugs": "https://github.com/ashtuchkin/iconv-lite/issues",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ashtuchkin/iconv-lite.git"
+        "url": "https://github.com/pillarjs/iconv-lite.git"
     },
     "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many popular npm packages; I'm opening PRs on several projects to fix it. I encourage anyone reading this to check any packages they maintain and implement the same fix if appropriate!)