### PR TITLE
chore: update performance tests to use bench-node for benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ npm install
 npm test
     
 # To view performance:
-node test/performance.js
+npm run test:performance
 
 # To view test coverage: 
-npm run test:coverage
+npm run test:cov
 open coverage/index.html
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test": "mocha --reporter spec --check-leaks --grep .",
         "test:ci": "nyc --exclude test --reporter=lcovonly --reporter=text npm test",
         "test:cov": "nyc --exclude test --reporter=html --reporter=text npm test",
-        "test:performance": "node performance/index.js",
+        "test:performance": "node --allow-natives-syntax performance/index.js",
         "test:tap": "mocha --reporter tap --check-leaks --grep .",
         "test:webpack": "npm pack && mv iconv-lite-*.tgz test/webpack/iconv-lite.tgz && cd test/webpack && npm install && npm run test && rm iconv-lite.tgz"
     },
@@ -34,6 +34,7 @@
     },
     "devDependencies": {
         "async": "^3.2.0",
+        "bench-node": "^0.10.0",
         "errto": "^0.2.1",
         "iconv": "^2.3.5",
         "mocha": "^6.2.2",

--- a/performance/index.js
+++ b/performance/index.js
@@ -1,67 +1,41 @@
-var iconv = require('iconv');
-var iconv_lite = require("../lib");
+const iconv = require('iconv');
+const iconv_lite = require("../lib");
+const { Suite } = require('bench-node');
 
-var encoding = process.argv[2] || "windows-1251";
-var convertTimes = 10000;
+const suite = new Suite({
+    pretty: true,
+    reporterOptions: {
+        printHeader: true // Set to false to hide system info header
+    }
+});
 
-var encodingStrings = {
+const encodingStrings = {
     'windows-1251': 'This is a test string 32 chars..',
-    'gbk':          '这是中文字符测试。。！@￥%12',
+    'gbk': '这是中文字符测试。。！@￥%12',
     'utf8': '这是中文字符测试。。！@￥%12This is a test string 48 chars..',
 };
-// Test encoding.
-var str = encodingStrings[encoding];
-if (!str) {
-    throw new Error('Don\'t support ' + encoding + ' performance test.');
+
+for (const [encoding, string] of Object.entries(encodingStrings)) {
+    suite.add(`${encoding}/encode/iconv-lite`, function () {
+        iconv_lite.encode(string, encoding);
+    })
+    suite.add(`${encoding}/encode/iconv`, function () {
+        const converter = new iconv.Iconv("utf8", encoding);
+        converter.convert(string);
+    })
+    suite.add(`${encoding}/decode/iconv-lite`, function (timer) {
+        const buffer = iconv_lite.encode(string, encoding)
+        timer.start();
+        iconv_lite.decode(buffer, encoding);
+        timer.end();
+    })
+    suite.add(`${encoding}/decode/iconv`, function (timer) {
+        const buffer = iconv_lite.encode(string, encoding)
+        timer.start();
+        const converter = new iconv.Iconv(encoding, "utf8");
+        converter.convert(buffer).toString();
+        timer.end();
+    })
 }
-for (var i = 0; i < 13; i++) {
-    str = str + str;
-}
 
-console.log('\n' + encoding + ' charset performance test:');
-console.log("\nEncoding "+str.length+" chars "+convertTimes+" times:");
-
-var start = Date.now();
-var converter = new iconv.Iconv("utf8", encoding);
-for (var i = 0; i < convertTimes; i++) {
-    var b = converter.convert(str);
-}
-
-var duration = Date.now() - start;
-var mbs = convertTimes*b.length/duration/1024;
-
-console.log("iconv: "+duration+"ms, "+mbs.toFixed(2)+" Mb/s.");
-
-var start = Date.now();
-for (var i = 0; i < convertTimes; i++) {
-    var b = iconv_lite.encode(str, encoding);
-}
-var duration = Date.now() - start;
-var mbs = convertTimes*b.length/duration/1024;
-
-console.log("iconv-lite: "+duration+"ms, "+mbs.toFixed(2)+" Mb/s.");
-
-
-// Test decoding.
-var buf = iconv_lite.encode(str, encoding);
-console.log("\nDecoding "+buf.length+" bytes "+convertTimes+" times:");
-
-var start = Date.now();
-var converter = new iconv.Iconv(encoding, "utf8");
-for (var i = 0; i < convertTimes; i++) {
-    var s = converter.convert(buf).toString();
-}
-var duration = Date.now() - start;
-var mbs = convertTimes*buf.length/duration/1024;
-
-console.log("iconv: "+duration+"ms, "+mbs.toFixed(2)+" Mb/s.");
-
-var start = Date.now();
-for (var i = 0; i < convertTimes; i++) {
-    var s = iconv_lite.decode(buf, encoding);
-}
-var duration = Date.now() - start;
-var mbs = convertTimes*buf.length/duration/1024;
-
-console.log("iconv-lite: "+duration+"ms, "+mbs.toFixed(2)+" Mb/s.");
-
+suite.run()


### PR DESCRIPTION
This simplifies our benchmark tests against node-iconv, using bench-node, which is a great tool for this kind of work.

It doesn’t matter that the tests can’t be run on Node 0.12 or older versions, since it’s already complicated to run node-iconv on those versions nowadays.

It would be great to be able to run the tests again on a new machine to see how much things have changed over the years in Node.js, but for that we’d need a clean machine, and we don’t have those resources available.