### PR TITLE
types: refactor Iconv type definition and add namespace export

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -46,7 +46,7 @@ declare namespace iconv {
     [key: string]: any;
   }
 
-  const iconv: {
+  export interface Iconv {
     // --- Basic API ---
 
     /** Encodes a `string` into a `Buffer`, using the provided `encoding`. */
@@ -60,11 +60,11 @@ declare namespace iconv {
 
     // --- Legacy aliases ---
 
-    /** Legacy alias for {@link iconv.encode}. */
-    toEncoding: typeof iconv.encode;
+    /** Legacy alias for {@link Iconv.encode}. */
+    toEncoding: Iconv["encode"];
 
-    /** Legacy alias for {@link iconv.decode}. */
-    fromEncoding: typeof iconv.decode;
+    /** Legacy alias for {@link Iconv.decode}. */
+    fromEncoding: Iconv["decode"];
 
     // --- Stream API ---
 
@@ -125,7 +125,11 @@ declare namespace iconv {
     readonly supportsStreams: boolean;
   }
 
+  const iconv: Iconv
+
   export type { iconv as Iconv, Encoding }
   export { iconv as default }
 }
+
 export = iconv
+export as namespace iconv


### PR DESCRIPTION
- Change `iconv` from const object to interface `Iconv`
- Update legacy alias types to use indexed access types instead of `typeof`
- Add const declaration for `iconv` using `Iconv` interface
- Add UMD namespace export with `export as namespace iconv`
close #363 