### PR TITLE
release: 0.7.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+## 0.7.2
+
+### 🐞 Bug fixes
+
+* Correction of CommonJS exports in TypeScript definitions - by [@plbstl](https://github.com/plbstl) in [#366](https://github.com/pillarjs/iconv-lite/pull/366)
+
+    Fixed the TypeScript definitions to correctly represent the CommonJS exports of the library. 
+    This resolves issues where consumers using TypeScript would encounter errors due to incorrect 
+    type definitions that did not align with the actual module exports.
+
 ## 0.7.1
 
 ### 🚀 Improvements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "iconv-lite",
     "description": "Convert character encodings in pure javascript.",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "license": "MIT",
     "keywords": [
         "iconv",


### PR DESCRIPTION
I plan to release this on Thursday the 8th cc: @pillarjs/express-tc @pillarjs/iconv-lite-collaborators 

tag: https://github.com/pillarjs/iconv-lite/releases/edit/untagged-9c50a88f8283d785ffc1

## 🐞 Bug fixes

* Correction of CommonJS exports in TypeScript definitions - by @plbstl in [#366](https://github.com/pillarjs/iconv-lite/pull/366)

    Fixed the TypeScript definitions to correctly represent the CommonJS exports of the library. 
    This resolves issues where consumers using TypeScript would encounter errors due to incorrect 
    type definitions that did not align with the actual module exports.
    
## Other changes
* Bump actions/setup-node from 4 to 6 by @dependabot[bot] in https://github.com/pillarjs/iconv-lite/pull/373
* Bump actions/checkout from 4 to 6 by @dependabot[bot] in https://github.com/pillarjs/iconv-lite/pull/374
* chore: use files field in package.json instead of .npmignore by @bjohansebas in https://github.com/pillarjs/iconv-lite/pull/372
* Bump github/codeql-action from 4.31.2 to 4.31.9 by @dependabot[bot] in https://github.com/pillarjs/iconv-lite/pull/375
* Bump actions/upload-artifact from 4 to 6 by @dependabot[bot] in https://github.com/pillarjs/iconv-lite/pull/377
* Bump actions/download-artifact from 6 to 7 by @dependabot[bot] in https://github.com/pillarjs/iconv-lite/pull/376


**Full Changelog**: https://github.com/pillarjs/iconv-lite/compare/v0.7.1...master