### PR TITLE
release: 1.0.0-alpha.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,16 @@
     This paves the way for supporting environments without Node.js Buffer, such as browsers using Uint8Array.
     This is a work in progress, so many parts still rely on Buffer internally, but the goal is to eventually have full support for a Uint8Array based implementation.
 
+- Update of the GBK encoding table according to changes in the specification - by [@bjohansebas](https://github.com/bjohansebas) in [#371](https://github.com/pillarjs/iconv-lite/pull/371)
+
+    The GBK encoding table was updated to reflect the latest changes in the Encoding Standard:
+
+    * A6D9–A6DF: Assigned 7 vertical presentation punctuation characters (︐︒︑︓︔︕︖) that were previously unmapped
+    * A6EC–A6ED: Assigned 2 presentation characters (︗︘) that were previously unmapped
+    * A6F3: Assigned a punctuation character (︙) that was previously unmapped
+    * FE50: Inserted characters 龴, 龵, 龶, 龷, 龸, 龹 at specific positions in the sequence
+    * FE80: Inserted characters 龺, 龻 at specific positions in the sequence
+
 ## 0.7.1
 
 ### 🚀 Improvements

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,22 @@
+## 1.0.0-alpha.1
+
+### ⚠️ Breaking changes
+
+- Remove support for Node <18 and safe-buffer dependency - by [@bjohansebas](https://github.com/bjohansebas), [@Phillip9587](https://github.com/Phillip9587) and [@TheThing](https://github.com/TheThing) in [#265](https://github.com/pillarjs/iconv-lite/pull/265) [#349](https://github.com/pillarjs/iconv-lite/pull/349)
+
+    Node.js versions prior to 18 are no longer supported. This allows us to remove the safe-buffer dependency and use native Buffer methods available in Node 18 and later. 
+
+- Use native TextDecoder for decoding - by [@JohnGu9](https://github.com/JohnGu9) and [@bjohansebas](https://github.com/bjohansebas) in [#316](https://github.com/pillarjs/iconv-lite/pull/316)
+
+    While this improves compatibility with web standards, some edge cases may behave differently because the implementation of TextDecoder in Node.js or other JavaScript runtimes has issues with the specification.
+    
+### 🚀 Improvements
+
+- Introduce backend abstraction layer to support to Uint8Array buffer implementation - by [@ashtuchkin](https://github.com/ashtuchkin)
+
+    This paves the way for supporting environments without Node.js Buffer, such as browsers using Uint8Array.
+    This is a work in progress, so many parts still rely on Buffer internally, but the goal is to eventually have full support for a Uint8Array based implementation.
+
 ## 0.7.1
 
 ### 🚀 Improvements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "iconv-lite",
     "description": "Convert character encodings in pure javascript.",
-    "version": "0.7.1",
+    "version": "1.0.0-alpha.1",
     "license": "MIT",
     "keywords": [
         "iconv",


### PR DESCRIPTION
I plan to release this alpha version on January 8. The reason for this is to start comparing our progress with the specification, and also because more breaking changes are coming. cc: @pillarjs/express-tc @pillarjs/iconv-lite-collaborators 

Tag: https://github.com/pillarjs/iconv-lite/releases/edit/untagged-281e80ec31c9ea2a7297

## ⚠️ Breaking changes

- Remove support for Node <18 and safe-buffer dependency - by @bjohansebas @Phillip9587 and @TheThing in [#265](https://github.com/pillarjs/iconv-lite/pull/265) and [#349](https://github.com/pillarjs/iconv-lite/pull/349)

    Node.js versions prior to 18 are no longer supported. This allows us to remove the safe-buffer dependency and use native Buffer methods available in Node 18 and later. 

- Use native TextDecoder for decoding - by @JohnGu9 and @bjohansebas in [#316](https://github.com/pillarjs/iconv-lite/pull/316)

    While this improves compatibility with web standards, some edge cases may behave differently because the implementation of TextDecoder in Node.js or other JavaScript runtimes has issues with the specification.
    
## 🚀 Improvements

- Introduce backend abstraction layer to support to Uint8Array buffer implementation - by @ashtuchkin

    This paves the way for supporting environments without Node.js Buffer, such as browsers using Uint8Array.
    This is a work in progress, so many parts still rely on Buffer internally, but the goal is to eventually have full support for a Uint8Array based implementation.


- Update of the GBK encoding table according to changes in the specification - by @bjohansebas in [#371](https://github.com/pillarjs/iconv-lite/pull/371)

    The GBK encoding table was updated to reflect the latest changes in the Encoding Standard:

    * A6D9–A6DF: Assigned 7 vertical presentation punctuation characters (︐︒︑︓︔︕︖) that were previously unmapped
    * A6EC–A6ED: Assigned 2 presentation characters (︗︘) that were previously unmapped
    * A6F3: Assigned a punctuation character (︙) that was previously unmapped
    * FE50: Inserted characters 龴, 龵, 龶, 龷, 龸, 龹 at specific positions in the sequence
    * FE80: Inserted characters 龺, 龻 at specific positions in the sequence

## What's Changed

* Updated test dependencies by @Phillip9587 in https://github.com/pillarjs/iconv-lite/pull/354
* cleanup: remove mergeModules helper function by @Phillip9587 in https://github.com/pillarjs/iconv-lite/pull/353
* chore(test:webpack): upgrade webpack 5 by @bjohansebas in https://github.com/pillarjs/iconv-lite/pull/362
* chore: bring chage of master by @bjohansebas in https://github.com/pillarjs/iconv-lite/pull/380

## New Contributors
* @Phillip9587 made their first contribution in https://github.com/pillarjs/iconv-lite/pull/354
* @JohnGu9 made their first contribution in https://github.com/pillarjs/iconv-lite/pull/316

**Full Changelog**: https://github.com/pillarjs/iconv-lite/compare/v0.7.1...v1