### PR TITLE
Implement invalidCharHandler for Single-Byte Encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ buf = iconv.encode("Sample input string", 'win1251');
 // Customize handling in case some characters are not representable in the target encoding
 buf = iconv.encode("Hello 世界", 'latin1', {
     invalidCharHandler: function(char, index) {
-        throw new Error("Cannot encode character " + JSON.stringify(char) + " at index " + index);
+        throw new Error("Cannot encode character " + char + " at index " + index);
     }
 });
 
 // Stop after first unsupported character (useful to avoid repeated warnings)
 buf = iconv.encode("Hello 世界", 'latin1', {
     invalidCharHandler: function(char, index) {
-        console.warn("Unsupported character " + JSON.stringify(char) + " at index " + index);
+        console.warn("Unsupported character " + char + " at index " + index);
         return true;
     }
 });

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ str = iconv.decode(Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f]), 'win1251');
 // Convert from a js string to an encoded buffer.
 buf = iconv.encode("Sample input string", 'win1251');
 
+// Customize handling in case some characters are not representable in the target encoding
+buf = iconv.encode("Hello 世界", 'latin1', {
+    invalidCharHandler: function(char, index) {
+        throw new Error("Cannot encode character " + JSON.stringify(char) + " at index " + index);
+    }
+});
+
+// Stop after first unsupported character (useful to avoid repeated warnings)
+buf = iconv.encode("Hello 世界", 'latin1', {
+    invalidCharHandler: function(char, index) {
+        console.warn("Unsupported character " + JSON.stringify(char) + " at index " + index);
+        return true;
+    }
+});
+// => null
+
 // Check if encoding is supported
 iconv.encodingExists("us-ascii")
 ```
@@ -109,7 +125,7 @@ This library supports UTF-32LE, UTF-32BE and UTF-32 encodings. Like the UTF-16 e
 ## Other notes
 
 When decoding, be sure to supply a Buffer to decode() method, otherwise [bad things usually happen](https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding).  
-Untranslatable characters are set to � or ?. No transliteration is currently supported.  
+Untranslatable characters are set to � or ?. For single-byte encoding, `invalidCharHandler` can be used to observe unsupported characters and warn or throw. You can also stop early by returning `true` from the handler, in which case `encode()` returns `null`. No transliteration is currently supported.  
 Node versions 0.10.31 and 0.11.13 are buggy, don't use them (see [#65](https://github.com/ashtuchkin/iconv-lite/issues/65), [#77](https://github.com/ashtuchkin/iconv-lite/issues/77)).  
 
 ## Testing

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -26,13 +26,16 @@ function SBCSCodec (codecOptions, iconv) {
   this.decodeBuf = Buffer.from(codecOptions.chars, "ucs2")
 
   // Encoding buffer.
-  var encodeBuf = Buffer.alloc(65536, iconv.defaultCharSingleByte.charCodeAt(0))
+  var defaultCharByte = iconv.defaultCharSingleByte.charCodeAt(0)
+  var encodeBuf = Buffer.alloc(65536, defaultCharByte)
 
   for (var i = 0; i < codecOptions.chars.length; i++) {
     encodeBuf[codecOptions.chars.charCodeAt(i)] = i
   }
 
   this.encodeBuf = encodeBuf
+  this.defaultCharByte = defaultCharByte
+  this.defaultCharCode = codecOptions.chars.charCodeAt(defaultCharByte)
 }
 
 SBCSCodec.prototype.encoder = SBCSEncoder
@@ -40,12 +43,47 @@ SBCSCodec.prototype.decoder = SBCSDecoder
 
 function SBCSEncoder (options, codec) {
   this.encodeBuf = codec.encodeBuf
+  this.invalidCharHandler = options && options.invalidCharHandler
+  this.defaultCharByte = codec.defaultCharByte
+  this.defaultCharCode = codec.defaultCharCode
 }
 
 SBCSEncoder.prototype.write = function (str) {
   var buf = Buffer.alloc(str.length)
+
+  var encodeBuf = this.encodeBuf
+  var invalidCharHandler = this.invalidCharHandler
+
+  if (typeof invalidCharHandler === "function") {
+    return encodeWithInvalidCharHandler(this, str, buf, encodeBuf, invalidCharHandler)
+  }
+
   for (var i = 0; i < str.length; i++) {
-    buf[i] = this.encodeBuf[str.charCodeAt(i)]
+    buf[i] = encodeBuf[str.charCodeAt(i)]
+  }
+
+  return buf
+}
+
+function encodeWithInvalidCharHandler (encoder, str, buf, encodeBuf, invalidCharHandler) {
+  var defaultCharByte = encoder.defaultCharByte
+  var defaultCharCode = encoder.defaultCharCode
+
+  for (var i = 0; i < str.length; i++) {
+    var charCode = str.charCodeAt(i)
+    var encodedByte = encodeBuf[charCode]
+
+    // `encodeBuf` uses default byte for unmappable chars. Disambiguate by
+    // allowing the codec character that genuinely maps to that default byte.
+    if (encodedByte !== defaultCharByte || charCode === defaultCharCode) {
+      buf[i] = encodedByte
+      continue
+    }
+
+    if (invalidCharHandler(str.charAt(i), i) === true) {
+      return null
+    }
+    buf[i] = encodedByte
   }
 
   return buf

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -68,6 +68,7 @@ SBCSEncoder.prototype.write = function (str) {
 function encodeWithInvalidCharHandler (encoder, str, buf, encodeBuf, invalidCharHandler) {
   var defaultCharByte = encoder.defaultCharByte
   var defaultCharCode = encoder.defaultCharCode
+  var codePointIndex = 0
 
   for (var i = 0; i < str.length; i++) {
     var charCode = str.charCodeAt(i)
@@ -77,28 +78,31 @@ function encodeWithInvalidCharHandler (encoder, str, buf, encodeBuf, invalidChar
     // allowing the codec character that genuinely maps to that default byte.
     if (encodedByte !== defaultCharByte || charCode === defaultCharCode) {
       buf[i] = encodedByte
+      codePointIndex++
       continue
     }
 
     // If an unencodable char is a surrogate pair, pass the full pair to the handler once.
-    // Index remains UTF-16 code-unit based and points to the high surrogate.
+    // Index is Unicode code-point based.
     if (charCode >= 0xD800 && charCode <= 0xDBFF && i + 1 < str.length) {
       var nextCharCode = str.charCodeAt(i + 1)
       if (nextCharCode >= 0xDC00 && nextCharCode <= 0xDFFF) {
-        if (invalidCharHandler(str.slice(i, i + 2), i) === true) {
+        if (invalidCharHandler(str.slice(i, i + 2), codePointIndex) === true) {
           return null
         }
         buf[i] = encodedByte
         buf[i + 1] = encodeBuf[nextCharCode]
         i++
+        codePointIndex++
         continue
       }
     }
 
-    if (invalidCharHandler(str.charAt(i), i) === true) {
+    if (invalidCharHandler(str.charAt(i), codePointIndex) === true) {
       return null
     }
     buf[i] = encodedByte
+    codePointIndex++
   }
 
   return buf

--- a/encodings/sbcs-codec.js
+++ b/encodings/sbcs-codec.js
@@ -80,6 +80,21 @@ function encodeWithInvalidCharHandler (encoder, str, buf, encodeBuf, invalidChar
       continue
     }
 
+    // If an unencodable char is a surrogate pair, pass the full pair to the handler once.
+    // Index remains UTF-16 code-unit based and points to the high surrogate.
+    if (charCode >= 0xD800 && charCode <= 0xDBFF && i + 1 < str.length) {
+      var nextCharCode = str.charCodeAt(i + 1)
+      if (nextCharCode >= 0xDC00 && nextCharCode <= 0xDFFF) {
+        if (invalidCharHandler(str.slice(i, i + 2), i) === true) {
+          return null
+        }
+        buf[i] = encodedByte
+        buf[i + 1] = encodeBuf[nextCharCode]
+        i++
+        continue
+      }
+    }
+
     if (invalidCharHandler(str.charAt(i), i) === true) {
       return null
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -31,10 +31,20 @@ declare namespace iconv {
     addBOM?: boolean;
     /** Override the default endianness for `UTF-32` encoding. */
     defaultEncoding?: "utf32be";
+    /**
+     * Called when encoding a character that cannot be represented in the target encoding.
+      * Return `true` to stop encoding early and make `iconv.encode()` return `null`,
+     *
+     * Currently used by single-byte encoders only.
+     *
+     * @param char - The unencodable character.
+     * @param index - The position of the character in the input string.
+     */
+    invalidCharHandler?: (char: string, index: number) => boolean | void;
   }
 
   export interface EncoderStream {
-    write(str: string): Buffer;
+    write(str: string): Buffer | null;
     end(): Buffer | undefined;
   }
 
@@ -51,7 +61,7 @@ declare namespace iconv {
   }
 
   /** Encodes a `string` into a `Buffer`, using the provided `encoding`. */
-  export function encode (content: string, encoding: Encoding, options?: EncodeOptions): Buffer
+  export function encode (content: string, encoding: Encoding, options?: EncodeOptions): Buffer | null
 
   /** Decodes a `Buffer` into a `string`, using the provided `encoding`. */
   export function decode (buffer: Buffer | Uint8Array, encoding: Encoding, options?: DecodeOptions): string

--- a/test/invalid-char-handler-test.js
+++ b/test/invalid-char-handler-test.js
@@ -54,6 +54,21 @@ describe("invalidCharHandler (SBCS)", function () {
     })
   })
 
+  it("supports error message with full character details (even for surrogate pairs)", function () {
+    var encoding = "latin1"
+
+    assert.throws(function () {
+      iconv.encode("Hello 🙂", encoding, {
+        invalidCharHandler: function (char, index) {
+          throw new Error("Cannot encode character " + char + " at index " + index + " to " + encoding)
+        }
+      })
+    }, function (err) {
+      assert.strictEqual(err.message, "Cannot encode character 🙂 at index 6 to latin1")
+      return true
+    })
+  })
+
   it("supports stopping SBCS encoding via handler return value", function () {
     var calls = []
     var res = iconv.encode("A世界B", "latin1", {

--- a/test/invalid-char-handler-test.js
+++ b/test/invalid-char-handler-test.js
@@ -1,0 +1,90 @@
+var assert = require("assert")
+var join = require("path").join
+var iconv = require(join(__dirname, "/../"))
+
+describe("invalidCharHandler (SBCS)", function () {
+  it("calls handler for unencodable chars", function () {
+    var calls = []
+    var res = iconv.encode("A世B", "latin1", {
+      invalidCharHandler: function (char, index) {
+        calls.push({ char: char, index: index })
+      }
+    })
+
+    assert.strictEqual(res.toString("binary"), "A?B")
+    assert.strictEqual(calls.length, 1)
+    assert.strictEqual(calls[0].char, "世")
+    assert.strictEqual(calls[0].index, 1)
+  })
+
+  it("does not call handler for encodable chars including '?'", function () {
+    var called = false
+    var res = iconv.encode("?A", "latin1", {
+      invalidCharHandler: function () {
+        called = true
+      }
+    })
+
+    assert.strictEqual(called, false)
+    assert.strictEqual(res.toString("binary"), "?A")
+  })
+
+  it("propagates thrown errors", function () {
+    assert.throws(function () {
+      iconv.encode("世", "latin1", {
+        invalidCharHandler: function () {
+          throw new Error("boom")
+        }
+      })
+    }, /boom/)
+  })
+
+  it("supports error message with full character details", function () {
+    var encoding = "latin1"
+
+    assert.throws(function () {
+      iconv.encode("Hello 世", encoding, {
+        invalidCharHandler: function (char, index) {
+          throw new Error("Cannot encode character " + char + " at index " + index + " to " + encoding)
+        }
+      })
+    }, function (err) {
+      assert.strictEqual(err.message, "Cannot encode character 世 at index 6 to latin1")
+      return true
+    })
+  })
+
+  it("supports stopping SBCS encoding via handler return value", function () {
+    var calls = []
+    var res = iconv.encode("A世界B", "latin1", {
+      invalidCharHandler: function (char, index) {
+        calls.push({ char: char, index: index })
+        return true
+      }
+    })
+
+    assert.strictEqual(res, null)
+    assert.strictEqual(calls.length, 1)
+    assert.strictEqual(calls[0].char, "世")
+    assert.strictEqual(calls[0].index, 1)
+  })
+
+  it("keeps default replacement when handler returns a value", function () {
+    var res = iconv.encode("世", "latin1", {
+      invalidCharHandler: function () {
+        return "!"
+      }
+    })
+
+    assert.strictEqual(res.toString("binary"), "?")
+  })
+
+  it("keeps default replacement when handler returns nothing", function () {
+    var res = iconv.encode("世", "latin1", {
+      invalidCharHandler: function () {
+      }
+    })
+
+    assert.strictEqual(res.toString("binary"), "?")
+  })
+})

--- a/test/invalid-char-handler-test.js
+++ b/test/invalid-char-handler-test.js
@@ -69,6 +69,22 @@ describe("invalidCharHandler (SBCS)", function () {
     })
   })
 
+  it("reports index as UTF-16 character position", function () {
+    var calls = []
+    var res = iconv.encode("A🙂世B", "latin1", {
+      invalidCharHandler: function (char, index) {
+        calls.push({ char: char, index: index })
+      }
+    })
+
+    assert.strictEqual(res.toString("binary"), "A???B")
+    assert.strictEqual(calls.length, 2)
+    assert.strictEqual(calls[0].char, "🙂")
+    assert.strictEqual(calls[0].index, 1)
+    assert.strictEqual(calls[1].char, "世")
+    assert.strictEqual(calls[1].index, 2)
+  })
+
   it("supports stopping SBCS encoding via handler return value", function () {
     var calls = []
     var res = iconv.encode("A世界B", "latin1", {
@@ -82,6 +98,7 @@ describe("invalidCharHandler (SBCS)", function () {
     assert.strictEqual(calls.length, 1)
     assert.strictEqual(calls[0].char, "世")
     assert.strictEqual(calls[0].index, 1)
+    // We don't call the handler for "界" because we stopped encoding after "世".
   })
 
   it("keeps default replacement when handler returns a value", function () {


### PR DESCRIPTION
As suggested in https://github.com/pillarjs/iconv-lite/issues/53#issue-32332094, this PR implements the `invalidCharHandler` as an optional argument part of the `EncodeOptions`. I remain open to discuss and make changes for this implementation.

## Motivation

To keep the scope of this PR small and focused, it's limited to only SBCS. I consider that even without having support for all encodings, this would still be beneficial since the majority of encodings that can't represent all Unicode codepoints remain single-byte.

I think this PR would solve an issue with the [recent update](https://github.com/editorconfig/editorconfig-vscode/pull/442) to the VS Code EditorConfig extension. The issue arise when it tried to enforce `latin1` encoding on-save without checking if the encoding would cause a loss of information (https://github.com/editorconfig/editorconfig-vscode/issues/474). This could be prevented if VS Code was able to detect lossy conversions and prevent them with a callback as mentioned [here](https://github.com/pillarjs/iconv-lite/issues/53#issuecomment-369969157).

## Implementation

As described in the README changes, the new feature would provide the following:

> For single-byte encoding, `invalidCharHandler` can be used to observe unsupported characters and warn or throw. You can also stop early by returning `true` from the handler, in which case `encode()` returns `null`.

The fact that returning `true` stops the encoding and make the encode function return `null` isn't mandatory obviously, but it can be nice if we don't want to force people to use a try-catch and a throw if they want to stop the encoding on the first error. 

Note that the way GitHub presents the diff doesn't make it clear that my changes would not cause any changes to the `SBCSEncoder.prototype.write` function if the `invalidCharHandler` is not present. Here's a better diff of the changes in my opinion to illustrate that point:

```diff
SBCSEncoder.prototype.write = function (str) {
  var buf = Buffer.alloc(str.length)
+
+  var encodeBuf = this.encodeBuf
+  var invalidCharHandler = this.invalidCharHandler
+
+  if (typeof invalidCharHandler === "function") {
+    return encodeWithInvalidCharHandler(this, str, buf, encodeBuf, invalidCharHandler)
+  }
+
  for (var i = 0; i < str.length; i++) {
-    buf[i] = this.encodeBuf[str.charCodeAt(i)]
+    buf[i] = encodeBuf[str.charCodeAt(i)]
  }
  return buf
}

+function encodeWithInvalidCharHandler (encoder, str, buf, encodeBuf, invalidCharHandler) {
+  var defaultCharByte = encoder.defaultCharByte
+  var defaultCharCode = encoder.defaultCharCode
+  var codePointIndex = 0
+
+  for (var i = 0; i < str.length; i++) {
+    var charCode = str.charCodeAt(i)
+    var encodedByte = encodeBuf[charCode]
+
+    // `encodeBuf` uses default byte for unmappable chars. Disambiguate by
+    // allowing the codec character that genuinely maps to that default byte.
+    if (encodedByte !== defaultCharByte || charCode === defaultCharCode) {
+      buf[i] = encodedByte
+      codePointIndex++
+      continue
+    }
+
+    // If an unencodable char is a surrogate pair, pass the full pair to the handler once.
+    // Index is Unicode code-point based.
+    if (charCode >= 0xD800 && charCode <= 0xDBFF && i + 1 < str.length) {
+      var nextCharCode = str.charCodeAt(i + 1)
+      if (nextCharCode >= 0xDC00 && nextCharCode <= 0xDFFF) {
+        if (invalidCharHandler(str.slice(i, i + 2), codePointIndex) === true) {
+          return null
+        }
+        buf[i] = encodedByte
+        buf[i + 1] = encodeBuf[nextCharCode]
+        i++
+        codePointIndex++
+        continue
+      }
+    }
+
+    if (invalidCharHandler(str.charAt(i), codePointIndex) === true) {
+      return null
+    }
+    buf[i] = encodedByte
+    codePointIndex++
+  }
+
+  return buf
+}
```

Regarding the issue of detecting if the presence of `?` or `�` is a sign that the current character can't be encoded (as discussed in https://github.com/pillarjs/iconv-lite/pull/283/changes), I solved the problem by passing down the `defaultCharCode` and `defaultCharByte` values so that we can perform the following check:

```js
 if (encodedByte !== defaultCharByte || charCode === defaultCharCode) 
```

Basically, we consider a character to be valid if it doesn't map to the `defaultCharByte` OR if the character code was already the `defaultCharCode` in the original string (ie. we already had a `?` or `�` in the original string).