### PR TITLE
fix: strip BOM when the wrapped decoder emits it only from end()

### DIFF
--- a/lib/bom-handling.js
+++ b/lib/bom-handling.js
@@ -44,5 +44,14 @@ StripBOMWrapper.prototype.write = function (buf) {
 }
 
 StripBOMWrapper.prototype.end = function () {
-  return this.decoder.end()
+  var res = this.decoder.end()
+  if (this.pass || !res) { return res }
+
+  if (res[0] === BOMChar) {
+    res = res.slice(1)
+    if (typeof this.options.stripBOM === "function") { this.options.stripBOM() }
+  }
+
+  this.pass = true
+  return res
 }

--- a/test/bom-test.js
+++ b/test/bom-test.js
@@ -2,6 +2,7 @@ var assert = require("assert")
 var Buffer = require("safer-buffer").Buffer
 var join = require("path").join
 var iconv = require(join(__dirname, "/../"))
+var StripBOM = require(join(__dirname, "/../lib/bom-handling")).StripBOM
 
 var sampleStr = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<俄语>данные</俄语>"
 var strBOM = "\ufeff"
@@ -64,6 +65,24 @@ describe("BOM Handling", function () {
 
     var body = Buffer.concat([iconv.encode(sampleStr, "utf16le")]).toString("hex")
     assert.equal(iconv.encode(sampleStr, "utf16", { addBOM: false }).toString("hex"), body)
+  })
+
+  it("strips BOM emitted only by the wrapped decoder's end()", function () {
+    function BufferingDecoder () { this.buf = "" }
+    BufferingDecoder.prototype.write = function (chunk) {
+      this.buf += chunk.toString("utf8")
+      return ""
+    }
+    BufferingDecoder.prototype.end = function () {
+      var res = this.buf; this.buf = ""; return res
+    }
+
+    var bomStripped = false
+    var wrapper = new StripBOM(new BufferingDecoder(), { stripBOM: function () { bomStripped = true } })
+    var out = wrapper.write(Buffer.from("﻿hello", "utf8"))
+    out += wrapper.end()
+    assert.equal(out, "hello")
+    assert(bomStripped)
   })
 
   it("when stripping BOM, calls callback 'stripBOM' if provided", function () {


### PR DESCRIPTION
StripBOMWrapper.end() previously returned the underlying decoder's final output verbatim. If every prior write() returned an empty string (leaving this.pass === false) and the decoder flushed its first characters only from end(), a leading BOM was forwarded to the caller and the stripBOM callback was never invoked. Mirror the write() BOM check in end() so the guarantee holds regardless of how the wrapped decoder chunks its output.