### PR TITLE
feat: support iso-8859-8-i and iso-8859-8-e charset labels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### 🚀 Improvements
+
+* Add `iso-8859-8-i` and `iso-8859-8-e` charset aliases - by [@baptistejamin](https://github.com/baptistejamin) in [#394](https://github.com/pillarjs/iconv-lite/pull/394)
+
 ## 0.7.2
 
 ### 🐞 Bug fixes

--- a/encodings/sbcs-data.js
+++ b/encodings/sbcs-data.js
@@ -109,6 +109,8 @@ module.exports = {
 
   hebrew: "iso88598",
   hebrew8: "iso88598",
+  iso88598i: "iso88598",
+  iso88598e: "iso88598",
 
   turkish: "iso88599",
   turkish8: "iso88599",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "stream": false
     },
     "devDependencies": {
-        "@arethetypeswrong/cli": "^0.17.4",
+        "@arethetypeswrong/cli": "^0.18.4",
         "@stylistic/eslint-plugin": "^5.1.0",
         "@stylistic/eslint-plugin-js": "^4.1.0",
         "@types/node": "^24.0.12",

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -19,7 +19,7 @@ describe("Encoding Existence - Prototype Properties", function () {
   })
 
   it("should detect all available encodings", function () {
-    assert.strictEqual(Object.keys(iconv.encodings).length, 416)
+    assert.strictEqual(Object.keys(iconv.encodings).length, 418)
   })
 })
 

--- a/test/sbcs-test.js
+++ b/test/sbcs-test.js
@@ -160,3 +160,20 @@ describe("Full SBCS encoding tests", function () {
     }
   }
 })
+
+describe("ISO-8859-8-I / ISO-8859-8-E aliases", function () {
+  var hebrewBytes = Buffer.from([0xE0, 0xE1, 0xE2])
+  var hebrewExpected = "\u05D0\u05D1\u05D2" // אבג
+
+  it("encodingExists recognizes the directional labels", function () {
+    assert(iconv.encodingExists("iso-8859-8-i"))
+    assert(iconv.encodingExists("iso-8859-8-e"))
+  })
+
+  it("decodes -i/-e labels identically to iso-8859-8", function () {
+    assert.strictEqual(iconv.decode(hebrewBytes, "iso-8859-8"), hebrewExpected)
+    assert.strictEqual(iconv.decode(hebrewBytes, "iso-8859-8-i"), hebrewExpected)
+    assert.strictEqual(iconv.decode(hebrewBytes, "ISO-8859-8-I"), hebrewExpected)
+    assert.strictEqual(iconv.decode(hebrewBytes, "iso-8859-8-e"), hebrewExpected)
+  })
+})

--- a/types/encodings.d.ts
+++ b/types/encodings.d.ts
@@ -276,6 +276,8 @@ export type Encoding =
   | "iso88596"
   | "iso88597"
   | "iso88598"
+  | "iso88598e"
+  | "iso88598i"
   | "iso88599"
   | "isoceltic"
   | "isoir100"


### PR DESCRIPTION
Hey there.

iconv-lite is used by a library we rely on: [mailparser](https://github.com/nodemailer/mailparser), which we use at [Crisp](https://crisp.chat).

We've received Hebrew emails with `charset="iso-8859-8-i"`, and they aren't decoded properly by iconv-lite. 

Right now, `encodingExists('iso-8859-8-i')` returns `false` and `decode(buf, 'iso-8859-8-i')` throws `Encoding not recognized`.

`iso-8859-8-i` and `iso-8859-8-e` are valid ISO charset names. The `-i` / `-e` suffix only describes text directionality (logical vs. visual BiDi order).


## What this PR does

- Adds `iso88598i` and `iso88598e` as aliases of `iso88598` in `encodings/sbcs-data.js`, next to the existing `hebrew` / `csisolatinhebrew` aliases.
- The canonicalizer in `lib/index.js` already strips the dashes (`iso-8859-8-i` → `iso88598i`), so both the dashed header form and the canonical form now resolve correctly.
- Regenerates `types/encodings.d.ts`
- Updated tests

The code was partially written with Cursor and Opus 4.8, and I reviewed it myself; it's an easy and safe PR.