### PR TITLE
chore: update node engine requirement to >=22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022]
         node-version: ["22.0.0", 22, 23, 24, 25, 26]
+        exclude:
+          # Skip: setup-node ships a broken bundled npm for the exact 22.0.0 build on Windows
+          # ("Cannot find module 'C:\npm\prefix\node_modules\npm\bin\npm-cli.js'")
+          - os: windows-2022
+            node-version: "22.0.0"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 'lts/*'
 
       - name: Install dependencies
         run: npm install
@@ -67,11 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2022]
-        node-version: ["18.0.0", 18, 19, 20, 21, 22, 23, 24, 25]
-        exclude:
-          # Skip: node-gyp build failure of "iconv" devDependency on Windows with Node 18.0.0
-          - os: windows-2022
-            node-version: "18.0.0"
+        node-version: ["22.0.0", 22, 23, 24, 25, 26]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -149,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["18", "*"]
+        node-version: ["22", "*"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           # ("Cannot find module 'C:\npm\prefix\node_modules\npm\bin\npm-cli.js'")
           - os: windows-2022
             node-version: "22.0.0"
+          # Skip: node-gyp build of the "iconv" devDependency fails on Windows with Node 26,
+          # which is built with thin-LTO and leaks clang/lld flags (-flto=thin, opt:lldltojobs)
+          # into the MSVC link step (LNK1117). Upstream node-gyp/Node toolchain issue.
+          - os: windows-2022
+            node-version: 26
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### ⚠️ Breaking changes
+
+- Remove support for Node <22 - by [@bjohansebas](https://github.com/bjohansebas) in [#396](https://github.com/pillarjs/iconv-lite/pull/396)
+
+    Node.js versions prior to 22 are no longer supported. This allows us to migrate to ESM and rely on `require(esm)`, which does not work correctly on earlier versions.
+
 ## 1.0.0-alpha.1
 
 ### ⚠️ Breaking changes

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "url": "https://github.com/pillarjs/iconv-lite.git"
     },
     "engines": {
-        "node": ">=18"
+        "node": ">=22"
     },
     "scripts": {
         "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "bench-node": "^0.10.0",
         "eslint": "^9.0.0",
         "expect-type": "^1.3.0",
-        "iconv": "^2.3.5",
+        "iconv": "^3.0.1",
         "mocha": "^10.8.2",
         "neostandard": "^0.12.0",    
         "nyc": "^17.1.0",

--- a/test/webpack/karma.conf.js
+++ b/test/webpack/karma.conf.js
@@ -4,7 +4,8 @@ const webpack = require("webpack")
 
 // Karma configuration
 // Generated on Sat May 23 2020 18:02:48 GMT-0400 (Eastern Daylight Time)
-process.env.CHROME_BIN = require("puppeteer").executablePath()
+// CHROME_BIN is provided by the `test` script (via `puppeteer browsers install chrome`),
+// since puppeteer's executablePath() is now async and can't be awaited in a sync config file.
 
 module.exports = function (config) {
   config.set({

--- a/test/webpack/package.json
+++ b/test/webpack/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "!note1": "NOTE: We do `npm pack` of the main iconv-lite package followed by installing it to create a copy of the package (not symlink).",
     "!note2": "This is needed because webpack4/watchpack1.7 crashes when trying to enumerate circular symlink.",
-    "test": "puppeteer browsers install chrome && karma start --browsers ChromeHeadlessCI"
+    "test": "CHROME_BIN=\"$(puppeteer browsers install chrome --format '{{path}}')\" karma start --browsers ChromeHeadlessCI"
   },
   "devDependencies": {
     "assert": "^2.1.0",

--- a/test/webpack/package.json
+++ b/test/webpack/package.json
@@ -18,7 +18,7 @@
     "mocha": "^7.2.0",
     "stream-browserify": "^3.0.0",
     "process": "0.11.10",
-    "puppeteer": "^24.34.0",
+    "puppeteer": "^25.2.1",
     "util": "^0.12.5",
     "webpack": "^5.103.0"
   },

--- a/test/webpack/package.json
+++ b/test/webpack/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "!note1": "NOTE: We do `npm pack` of the main iconv-lite package followed by installing it to create a copy of the package (not symlink).",
     "!note2": "This is needed because webpack4/watchpack1.7 crashes when trying to enumerate circular symlink.",
-    "test": "karma start --browsers ChromeHeadlessCI"
+    "test": "puppeteer browsers install chrome && karma start --browsers ChromeHeadlessCI"
   },
   "devDependencies": {
     "assert": "^2.1.0",


### PR DESCRIPTION
This is to support require(esm)