### PR TITLE
feat: enhance UTF-16 encoding/decoding with WHATWG compliance

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -6,7 +6,9 @@
     "backends/**"
   ],
   "exclude": [
-    "test/**"
+    "test/**",
+    "**/*.d.ts",
+    "lib/index-web.js"
   ],
   "reporter": [
     "text"

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@
 
     The `utf-16` label still auto-detects endianness (UTF-16LE vs UTF-16BE) from the BOM and a space-based heuristic, defaulting to UTF-16LE. This is kept as an iconv-lite extension even though it is not spec-compliant — the Encoding Standard maps the `utf-16` label directly to UTF-16LE.
 
+    The WHATWG UTF-16 label aliases are now recognized: `unicode`, `csunicode`, `iso-10646-ucs-2` and `unicodefeff` map to UTF-16LE, and `unicodefffe` maps to UTF-16BE.
+
+    Note: iconv-lite still matches encoding labels leniently (it normalizes away surrounding/embedded punctuation and control characters), so it accepts some labels the Encoding Standard would reject. Making label resolution fully spec-strict is tracked as a follow-up.
+
 ### 🚀 Improvements
 
 - Add an opt-in `fatal` decoding option - by [@bjohansebas](https://github.com/bjohansebas) in [#402](https://github.com/pillarjs/iconv-lite/pull/402)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,18 @@
 
     Node.js versions prior to 22 are no longer supported. This allows us to migrate to ESM and rely on `require(esm)`, which does not work correctly on earlier versions.
 
+- Make the UTF-16 decoder WHATWG-conformant by [@bjohansebas](https://github.com/bjohansebas) in [#402](https://github.com/pillarjs/iconv-lite/pull/402)
+
+    UTF-16LE/BE (and the `ucs2`/`ucs-2` aliases) now decode through the standard `TextDecoder`, matching the Encoding Standard's shared UTF-16 decoder. As a result, unpaired/invalid surrogates and a trailing odd byte are replaced with U+FFFD instead of being passed through, and the Node and Web backends now behave identically. The decoder also no longer depends on the backend.
+
+    The `utf-16` label still auto-detects endianness (UTF-16LE vs UTF-16BE) from the BOM and a space-based heuristic, defaulting to UTF-16LE. This is kept as an iconv-lite extension even though it is not spec-compliant — the Encoding Standard maps the `utf-16` label directly to UTF-16LE.
+
+### 🚀 Improvements
+
+- Add an opt-in `fatal` decoding option - by [@bjohansebas](https://github.com/bjohansebas) in [#402](https://github.com/pillarjs/iconv-lite/pull/402)
+
+    Passing `{ fatal: true }` to `iconv.decode(...)` makes the TextDecoder-backed encodings (UTF-8, UTF-16LE/BE) throw on invalid input, per the WHATWG Encoding Standard, instead of replacing it with U+FFFD. The default stays lenient (replacement).
+
 ## 1.0.0-alpha.1
 
 ### ⚠️ Breaking changes

--- a/encodings/internal.js
+++ b/encodings/internal.js
@@ -65,11 +65,11 @@ function InternalDecoder (options, codec) {
         }
       }
     }
-  } else if (codec.enc === "ucs2") {
-    this.decoder = new TextDecoder("utf-16", { ignoreBOM: options?.stripBOM === false || typeof options?.stripBOM === "function" })
-  }
-  else {
-    this.decoder = new TextDecoder(codec.enc, { ignoreBOM: options?.stripBOM === false || typeof options?.stripBOM === "function" })
+  } else {
+    this.decoder = new TextDecoder(codec.enc, {
+      ignoreBOM: options?.stripBOM === false || typeof options?.stripBOM === "function",
+      fatal: !!options?.fatal
+    })
   }
 }
 
@@ -81,7 +81,9 @@ InternalDecoder.prototype.write = function (buf) {
 }
 
 InternalDecoder.prototype.end = function () {
-  return this.decoder.decode(undefined, { stream: true })
+  // Final flush (stream: false) so a trailing incomplete sequence is finalized: replaced with
+  // U+FFFD, or (in fatal mode) raised as an error, per the WHATWG Encoding Standard.
+  return this.decoder.decode()
 }
 
 // ------------------------------------------------------------------------------

--- a/encodings/utf16.js
+++ b/encodings/utf16.js
@@ -212,6 +212,15 @@ function detectEncoding (bufs, defaultEncoding) {
 // == Exports ==================================================================
 
 exports.utf16le = Utf16LECodec
-exports.ucs2 = "utf16le" // Alias
+// Aliases that the WHATWG Encoding Standard maps to UTF-16LE (keys are canonicalized labels).
+exports.ucs2 = "utf16le"
+exports.unicode = "utf16le"
+exports.csunicode = "utf16le"
+exports.iso10646ucs2 = "utf16le"
+exports.unicodefeff = "utf16le"
+
 exports.utf16be = Utf16BECodec
+// Alias that the WHATWG Encoding Standard maps to UTF-16BE.
+exports.unicodefffe = "utf16be"
+
 exports.utf16 = Utf16Codec

--- a/encodings/utf16.js
+++ b/encodings/utf16.js
@@ -1,21 +1,45 @@
 "use strict"
 
-// == UTF16-LE codec. ==========================================================
-// Note: We're not using Node.js native codec because StringDecoder implementation is buggy
-// (adds \0 in some chunks; doesn't flag non-even number of bytes). We do use raw encoding/decoding
-// routines for performance where possible, though.
+// == UTF16-LE / UTF16-BE codecs ===============================================
+//
+// Decoding uses the WHATWG-standard TextDecoder (available in both Node and browsers), so it
+// conforms to the Encoding Standard's "shared UTF-16 decoder": invalid input (lone/unpaired
+// surrogates, a trailing odd byte) is replaced with U+FFFD ('�'). This also makes the Node and Web
+// backends behave identically, so the decoder no longer depends on the backend.
+//
+// Note: the Encoding Standard defines no UTF-16 *encoder* (only UTF-8), so the encoders below are an
+// iconv-lite extension; they pass lone surrogates through and use the backend only for the final
+// "bytes -> result" step, so that encoding keeps returning a Buffer in Node.
 
-exports.utf16le = class Utf16LECodec {
+// == UTF16-LE codec. ==========================================================
+
+class Utf16LECodec {
   createEncoder (options, iconv) {
     return new Utf16LEEncoder(iconv.backend)
   }
 
   createDecoder (options, iconv) {
-    return new Utf16LEDecoder(iconv.backend, iconv.defaultCharUnicode)
+    return new Utf16EndianDecoder("utf-16le", options)
   }
 
   get bomAware () { return true }
 }
+
+// == UTF16-BE codec. ==========================================================
+
+class Utf16BECodec {
+  createEncoder (options, iconv) {
+    return new Utf16BEEncoder(iconv.backend)
+  }
+
+  createDecoder (options, iconv) {
+    return new Utf16EndianDecoder("utf-16be", options)
+  }
+
+  get bomAware () { return true }
+}
+
+// == Encoders =================================================================
 
 class Utf16LEEncoder {
   constructor (backend) {
@@ -23,8 +47,10 @@ class Utf16LEEncoder {
   }
 
   write (str) {
-    const bytes = this.backend.allocBytes(str.length * 2)
-    const chars = new Uint16Array(bytes.buffer, bytes.byteOffset, str.length)
+    // On little-endian platforms (assumed throughout this lib) a Uint16Array view writes the
+    // code units in the correct byte order directly.
+    const bytes = new Uint8Array(str.length * 2)
+    const chars = new Uint16Array(bytes.buffer, 0, str.length)
     for (let i = 0; i < str.length; i++) {
       chars[i] = str.charCodeAt(i)
     }
@@ -34,230 +60,58 @@ class Utf16LEEncoder {
   end () {}
 }
 
-class Utf16LEDecoder {
-  constructor (backend, defaultChar) {
-    this.backend = backend
-    this.defaultChar = defaultChar
-    this.leadByte = -1
-    this.leadSurrogate = undefined
-  }
-
-  write (buf) {
-    // NOTE: This function is mostly the same as Utf16BEDecoder.write() with bytes swapped.
-    //   Please keep them in sync.
-    // NOTE: The logic here is more complicated than barely necessary due to several limitations:
-    //  1. Input data chunks can split 2-byte code units, making 'leadByte' necessary.
-    //  2. Input data chunks can split valid surrogate pairs, making 'leadSurrogate' necessary.
-    //  3. rawCharsToResult() of Web backend converts all lone surrogates to '�', so we need to make
-    //     sure we don't feed it parts of valid surrogate pairs.
-    //  4. For performance reasons we want to use initial buffer as much as we can. This is not
-    //     possible if after our calculations the 2-byte memory alignment of a Uint16Array is lost,
-    //     in which case we have to do a copy.
-
-    if (buf.length == 0) {
-      return ""
-    }
-    let offset = 0
-    let byteLen = buf.length
-
-    // Process previous leadByte
-    let prefix = ""
-    if (this.leadByte !== -1) {
-      offset++; byteLen--
-      prefix = String.fromCharCode(this.leadByte | (buf[0] << 8))
-    }
-
-    // Set new leadByte if needed
-    if (byteLen & 1) {
-      this.leadByte = buf[buf.length - 1]
-      byteLen--
-    } else {
-      this.leadByte = -1
-    }
-
-    // Process leadSurrogate
-    if (prefix.length || byteLen) {
-      // Add high surrogate from previous chunk.
-      if (this.leadSurrogate) {
-        if (prefix.length) {
-          prefix = this.leadSurrogate + prefix
-        } else {
-          // Make sure 'chars' don't start with a lone low surrogate; it will mess with rawCharsToResult.
-          prefix = this.leadSurrogate + String.fromCharCode(buf[offset] | (buf[offset + 1] << 8))
-          offset += 2; byteLen -= 2
-        }
-        this.leadSurrogate = undefined
-      }
-
-      // Slice off a new high surrogate at the end of the current chunk.
-      if (byteLen) {
-        const lastIdx = offset + byteLen - 2
-        const lastChar = buf[lastIdx] | (buf[lastIdx + 1] << 8)
-        if (lastChar >= 0xD800 && lastChar < 0xDC00) {
-          this.leadSurrogate = String.fromCharCode(lastChar)
-          byteLen -= 2
-        }
-      } else { // slice from prefix
-        const lastChar = prefix.charCodeAt(prefix.length - 1)
-        if (lastChar >= 0xD800 && lastChar < 0xDC00) {
-          this.leadSurrogate = prefix[prefix.length - 1]
-          prefix = prefix.slice(0, -1)
-        }
-      }
-    }
-
-    let chars
-    if ((buf.byteOffset + offset) & 1 === 0) {
-      // If byteOffset is aligned, just use the ArrayBuffer from input buf.
-      chars = new Uint16Array(buf.buffer, buf.byteOffset + offset, byteLen >> 1)
-    } else {
-      // If byteOffset is NOT aligned, create a new aligned buffer and copy the data.
-      chars = this.backend.allocRawChars(byteLen >> 1)
-      const srcByteView = new Uint8Array(buf.buffer, buf.byteOffset + offset, byteLen)
-      const destByteView = new Uint8Array(chars.buffer, chars.byteOffset, byteLen)
-      destByteView.set(srcByteView)
-    }
-
-    return prefix + this.backend.rawCharsToResult(chars, chars.length)
-  }
-
-  end () {
-    if (this.leadSurrogate || this.leadByte !== -1) {
-      const res = (this.leadSurrogate ? this.leadSurrogate : "") + (this.leadByte !== -1 ? this.defaultChar : "")
-      this.leadSurrogate = undefined
-      this.leadByte = -1
-      return res
-    }
-  }
-}
-exports.ucs2 = "utf16le"  // Alias
-
-// == UTF16-BE codec. ==========================================================
-
-exports.utf16be = class Utf16BECodec {
-  createEncoder (options, iconv) {
-    return new Utf16BEEncoder(iconv.backend)
-  }
-
-  createDecoder (options, iconv) {
-    return new Utf16BEDecoder(iconv.backend, iconv.defaultCharUnicode)
-  }
-
-  get bomAware () { return true }
-}
-
 class Utf16BEEncoder {
   constructor (backend) {
     this.backend = backend
   }
 
   write (str) {
-    const bytes = this.backend.allocBytes(str.length * 2)
-    let bytesPos = 0
+    const bytes = new Uint8Array(str.length * 2)
+    let pos = 0
     for (let i = 0; i < str.length; i++) {
       const char = str.charCodeAt(i)
-      bytes[bytesPos++] = char >> 8
-      bytes[bytesPos++] = char & 0xff
+      bytes[pos++] = char >> 8
+      bytes[pos++] = char & 0xff
     }
-    return this.backend.bytesToResult(bytes, bytesPos)
+    return this.backend.bytesToResult(bytes, pos)
   }
 
   end () {}
 }
 
-class Utf16BEDecoder {
-  constructor (backend, defaultChar) {
-    this.backend = backend
-    this.defaultChar = defaultChar
-    this.leadByte = -1
-    this.leadSurrogate = undefined
+// == Decoder (shared between LE and BE) =======================================
+// Thin wrapper over the WHATWG TextDecoder, which implements the Encoding Standard's shared UTF-16
+// decoder. Streaming (chunk boundaries, split code units and split surrogate pairs) and U+FFFD
+// replacement of invalid input are handled by TextDecoder itself.
+// `ignoreBOM: true` leaves BOM stripping to iconv-lite's BOM handling (these codecs are bomAware).
+
+class Utf16EndianDecoder {
+  constructor (label, options) {
+    // Opt-in WHATWG "fatal" mode: throw on invalid input instead of replacing with U+FFFD.
+    // Default (fatal: false) matches TextDecoder's default and iconv-lite's lenient behavior.
+    this.decoder = new TextDecoder(label, { ignoreBOM: true, fatal: !!(options && options.fatal) })
   }
 
   write (buf) {
-    // NOTE: This function is mostly copy/paste from Utf16LEDecoder.write() with bytes swapped.
-    // Please keep them in sync. Comments in that function apply here too.
-    if (buf.length === 0) {
-      return ""
-    }
-
-    let offset = 0
-    let byteLen = buf.length
-
-    // Process previous leadByte
-    let prefix = ""
-    if (this.leadByte !== -1) {
-      offset++; byteLen--
-      prefix = String.fromCharCode((this.leadByte << 8) | buf[0])
-    }
-
-    // Set new leadByte
-    if (byteLen & 1) {
-      this.leadByte = buf[buf.length - 1]
-      byteLen--
-    } else {
-      this.leadByte = -1
-    }
-
-    // Process leadSurrogate
-    if (prefix.length || byteLen) {
-      // Add high surrogate from previous chunk.
-      if (this.leadSurrogate) {
-        if (prefix.length) {
-          prefix = this.leadSurrogate + prefix
-        } else {
-          // Make sure 'chars' don't start with a lone low surrogate; it will mess with rawCharsToResult.
-          prefix = this.leadSurrogate + String.fromCharCode((buf[offset] << 8) | buf[offset + 1])
-          offset += 2; byteLen -= 2
-        }
-        this.leadSurrogate = undefined
-      }
-
-      // Slice off a new high surrogate at the end of the current chunk.
-      if (byteLen) {
-        const lastIdx = offset + byteLen - 2
-        const lastChar = (buf[lastIdx] << 8) | buf[lastIdx + 1]
-        if (lastChar >= 0xD800 && lastChar < 0xDC00) {
-          this.leadSurrogate = String.fromCharCode(lastChar)
-          byteLen -= 2
-        }
-      } else { // slice from prefix
-        const lastChar = prefix.charCodeAt(prefix.length - 1)
-        if (lastChar >= 0xD800 && lastChar < 0xDC00) {
-          this.leadSurrogate = prefix[prefix.length - 1]
-          prefix = prefix.slice(0, -1)
-        }
-      }
-    }
-
-    // Convert the main chunk of bytes
-    const chars = this.backend.allocRawChars(byteLen >> 1)
-    const srcBytes = new DataView(buf.buffer, buf.byteOffset + offset, byteLen)
-    for (let i = 0; i < chars.length; i++) {
-      chars[i] = srcBytes.getUint16(i * 2)
-    }
-
-    return prefix + this.backend.rawCharsToResult(chars, chars.length)
+    return this.decoder.decode(buf, { stream: true })
   }
 
   end () {
-    if (this.leadSurrogate || this.leadByte !== -1) {
-      const res = (this.leadSurrogate ? this.leadSurrogate : "") + (this.leadByte !== -1 ? this.defaultChar : "")
-      this.leadSurrogate = undefined
-      this.leadByte = -1
-      return res
-    }
+    const res = this.decoder.decode()
+    return res.length > 0 ? res : undefined
   }
 }
 
 // == UTF-16 codec =============================================================
-// Decoder chooses automatically from UTF-16LE and UTF-16BE using BOM and space-based heuristic.
-// Defaults to UTF-16LE, as it's prevalent and default in Node.
+// iconv-lite extension (NOT WHATWG: the Encoding Standard maps the "utf-16" label straight to
+// UTF-16LE). The decoder chooses automatically from UTF-16LE and UTF-16BE using the BOM and a
+// space-based heuristic, defaulting to UTF-16LE (prevalent and the default in Node).
 // http://en.wikipedia.org/wiki/UTF-16 and http://encoding.spec.whatwg.org/#utf-16le
 // Decoder default can be changed: iconv.decode(buf, 'utf16', {defaultEncoding: 'utf-16be'});
 
 // Encoder uses UTF-16LE and prepends BOM (which can be overridden with addBOM: false).
 
-exports.utf16 = class Utf16Codec {
+class Utf16Codec {
   createEncoder (options, iconv) {
     options = options || {}
     if (options.addBOM === undefined)
@@ -354,3 +208,10 @@ function detectEncoding (bufs, defaultEncoding) {
   // Couldn't decide (likely all zeros or not enough data).
   return defaultEncoding || "utf-16le"
 }
+
+// == Exports ==================================================================
+
+exports.utf16le = Utf16LECodec
+exports.ucs2 = "utf16le" // Alias
+exports.utf16be = Utf16BECodec
+exports.utf16 = Utf16Codec

--- a/performance/index.js
+++ b/performance/index.js
@@ -42,6 +42,12 @@ for (const [encoding, string] of Object.entries(encodingStrings)) {
     converter.convert(buffer).toString()
     timer.end()
   })
+  suite.add(`${encoding}/decode/native-TextDecoder`, function (timer) {
+    const buffer = iconvLite.encode(string, encoding)
+    timer.start()
+    new TextDecoder(encoding).decode(buffer)
+    timer.end()
+  })
 }
 
 suite.run()

--- a/performance/index.js
+++ b/performance/index.js
@@ -16,7 +16,9 @@ const suite = new Suite({
 const encodingStrings = {
   "windows-1251": "This is a test string 32 chars..",
   gbk: "这是中文字符测试。。！@￥%12",
-  utf8: "这是中文字符测试。。！@￥%12This is a test string 48 chars.."
+  utf8: "这是中文字符测试。。！@￥%12This is a test string 48 chars..",
+  "utf-16le": "这是中文字符测试。。！@￥%12This is a test string 48 chars..",
+  "utf-16be": "这是中文字符测试。。！@￥%12This is a test string 48 chars.."
 }
 
 for (const [encoding, string] of Object.entries(encodingStrings)) {

--- a/performance/index.js
+++ b/performance/index.js
@@ -21,33 +21,41 @@ const encodingStrings = {
   "utf-16be": "这是中文字符测试。。！@￥%12This is a test string 48 chars.."
 }
 
-for (const [encoding, string] of Object.entries(encodingStrings)) {
-  suite.add(`${encoding}/encode/iconv-lite`, function () {
-    iconvLite.encode(string, encoding)
-  })
-  suite.add(`${encoding}/encode/iconv`, function () {
-    const converter = new iconv.Iconv("utf8", encoding)
-    converter.convert(string)
-  })
-  suite.add(`${encoding}/decode/iconv-lite`, function (timer) {
-    const buffer = iconvLite.encode(string, encoding)
-    timer.start()
-    iconvLite.decode(buffer, encoding)
-    timer.end()
-  })
-  suite.add(`${encoding}/decode/iconv`, function (timer) {
-    const buffer = iconvLite.encode(string, encoding)
-    timer.start()
-    const converter = new iconv.Iconv(encoding, "utf8")
-    converter.convert(buffer).toString()
-    timer.end()
-  })
-  suite.add(`${encoding}/decode/native-TextDecoder`, function (timer) {
-    const buffer = iconvLite.encode(string, encoding)
-    timer.start()
-    new TextDecoder(encoding).decode(buffer)
-    timer.end()
-  })
+// How many times the base string is repeated for each size variant. "small" is a typical short
+// string; "large" approximates bulk payloads, where native/SIMD paths and per-call overhead differ.
+const sizes = { small: 1, large: 100 }
+
+for (const [encoding, baseString] of Object.entries(encodingStrings)) {
+  for (const [size, repeat] of Object.entries(sizes)) {
+    const string = baseString.repeat(repeat)
+
+    suite.add(`${encoding}/${size}/encode/iconv-lite`, function () {
+      iconvLite.encode(string, encoding)
+    })
+    suite.add(`${encoding}/${size}/encode/iconv`, function () {
+      const converter = new iconv.Iconv("utf8", encoding)
+      converter.convert(string)
+    })
+    suite.add(`${encoding}/${size}/decode/iconv-lite`, function (timer) {
+      const buffer = iconvLite.encode(string, encoding)
+      timer.start()
+      iconvLite.decode(buffer, encoding)
+      timer.end()
+    })
+    suite.add(`${encoding}/${size}/decode/iconv`, function (timer) {
+      const buffer = iconvLite.encode(string, encoding)
+      timer.start()
+      const converter = new iconv.Iconv(encoding, "utf8")
+      converter.convert(buffer).toString()
+      timer.end()
+    })
+    suite.add(`${encoding}/${size}/decode/native-TextDecoder`, function (timer) {
+      const buffer = iconvLite.encode(string, encoding)
+      timer.start()
+      new TextDecoder(encoding).decode(buffer)
+      timer.end()
+    })
+  }
 }
 
 suite.run()

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -20,7 +20,7 @@ describe("Encoding Existence - Prototype Properties", function () {
   })
 
   it("should detect all available encodings", function () {
-    assert.strictEqual(Object.keys(iconv.encodings).length, 416)
+    assert.strictEqual(Object.keys(iconv.encodings).length, 421)
   })
 })
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -72,6 +72,13 @@ describe("Generic UTF8-UCS2 tests", function () {
     assert.throws(function () { iconv.decode(Buffer.from("a"), "xxx") })
   })
 
+  it("Opt-in fatal mode throws on invalid utf8, replaces by default", function () {
+    var invalid = Buffer.from([0xff, 0xfe, 0xfd])
+    assert.throws(function () { iconv.decode(invalid, "utf8", { fatal: true }) })
+    assert.strictEqual(iconv.decode(Buffer.from("abc"), "utf8", { fatal: true }), "abc")
+    assert.strictEqual(iconv.decode(invalid, "utf8"), "���") // default: replacement, no throw.
+  })
+
   it("Convert non-strings and non-buffers", function () {
     assert.throws(function () {
       iconv.encode({}, "utf8")

--- a/test/utf16.test.js
+++ b/test/utf16.test.js
@@ -318,6 +318,19 @@ describe("UTF-16 decoder #node-web", function () {
       iconv.decode(weirdBuf, encBE)
     )
   })
+
+  it("keeps decoding chunks fed after the endianness was detected", function () {
+    const d = iconv.getDecoder(enc)
+    let res = d.write(utf16leBuf) // 16 bytes -> triggers detection, sets the inner decoder.
+    res += d.write(utf16leBuf) // Subsequent chunk: inner decoder already chosen.
+    res += d.end() || ""
+    assert.equal(res, testStr + testStr)
+  })
+
+  it("uses only the first 100 code units for the space heuristic", function () {
+    const longStr = "a".repeat(120) // >100 code units, no BOM -> heuristic loop hits its cap.
+    assert.equal(iconv.decode(iconv.encode(longStr, encLE), enc), longStr)
+  })
 })
 
 // Adapted from @exodus/bytes' utf16 tests: unpaired/invalid surrogates must be replaced with

--- a/test/utf16.test.js
+++ b/test/utf16.test.js
@@ -28,6 +28,18 @@ describe("ucs2 alias #node-web", function () {
   })
 })
 
+describe("WHATWG utf-16 label aliases #node-web", function () {
+  for (const label of ["unicode", "csunicode", "iso-10646-ucs-2", "unicodefeff"]) {
+    it(`'${label}' decodes as UTF-16LE`, function () {
+      assert.equal(iconv.decode(utf16leBuf, label), iconv.decode(utf16leBuf, "utf-16le"))
+    })
+  }
+
+  it("'unicodefffe' decodes as UTF-16BE", function () {
+    assert.equal(iconv.decode(utf16beBuf, "unicodefffe"), iconv.decode(utf16beBuf, "utf-16be"))
+  })
+})
+
 describe("UTF-16LE encoder #node-web", function () {
   const enc = "utf16-le"
   it("encodes basic strings correctly", function () {

--- a/test/utf16.test.js
+++ b/test/utf16.test.js
@@ -14,6 +14,20 @@ const utf16beBOM = utils.bytes("fe ff")
 const sampleStr = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<数据>נְתוּנִים</数据>"
 const weirdBuf = utils.bytes("15 16 17 18") // Can't automatically detect whether it's LE or BE.
 
+describe("ucs2 alias #node-web", function () {
+  it("decodes identically to utf-16le", function () {
+    assert.equal(iconv.decode(utf16leBuf, "ucs2"), iconv.decode(utf16leBuf, "utf-16le"))
+  })
+
+  it("encodes identically to utf-16le", function () {
+    assert.equal(hex(iconv.encode(testStr, "ucs2")), hex(iconv.encode(testStr, "utf-16le")))
+  })
+
+  it("resolves the 'ucs-2' label too", function () {
+    assert.equal(iconv.decode(utf16leBuf, "ucs-2"), iconv.decode(utf16leBuf, "utf-16le"))
+  })
+})
+
 describe("UTF-16LE encoder #node-web", function () {
   const enc = "utf16-le"
   it("encodes basic strings correctly", function () {
@@ -71,26 +85,21 @@ describe("UTF-16LE decoder #node-web", function () {
     assert.equal(iconv.decode(utils.bytes([0x61]), enc), "�")
   })
 
-  // NOTE: Node and Web backends differ in handling invalid surrogates: node passes them through, web
-  // replaces them with '�'. Don't know what to do with this, as I haven't found a performant way
-  // to unify them while keeping compatibility with Node 4.5 where there's no TextDecoder.
-  // Not too worried as it seems like an edge case, but something to be aware of.
-  // When this is resolved, please add the same tests to utf16-be codec too.
-  it.skip("passes through invalid surrogates as-is", function () {
+  // Per the WHATWG Encoding Standard, the UTF-16 decoder replaces unpaired/invalid surrogates with
+  // U+FFFD. (This behaves identically across the Node and Web backends.)
+  it("replaces unpaired surrogates with U+FFFD (per WHATWG)", function () {
     // prettier-ignore
     const buf = utils.bytes("2000 00d8 2000 00de 2000 00de 00d8 2000 00d8")
-    assert.equal(iconv.decode(buf, enc), " \uD800 \uDE00 \uDE00\uD800 \uD800")
+    assert.equal(iconv.decode(buf, enc), " � � �� �")
   })
 
-  // See comment in the test above.
-  it.skip("has full 16-bit transparency", function () {
+  it("round-trips all non-surrogate BMP code points", function () {
     let s = ""
-    const arr = []
-    for (let i = 0; i < 65536; i++) {
+    for (let i = 0; i < 0x10000; i++) {
+      if (i >= 0xD800 && i <= 0xDFFF) continue // Surrogates aren't round-trippable per WHATWG.
       s += String.fromCharCode(i)
-      arr.push(i & 0xff, i >> 8)
     }
-    assert.equal(iconv.decode(utils.bytes(arr), enc), s)
+    assert.equal(iconv.decode(iconv.encode(s, enc), enc), s)
   })
 
   it(
@@ -128,23 +137,23 @@ describe("UTF-16LE decoder #node-web", function () {
     utils.checkDecoderChunks(enc, [
       {
         inputs: [[0x3e], [0xd9], [0x3d], [0xd8], [0x3b], [0xde]],
-        outputs: ["", "", "", "\uD93E", "", "\uD83D\uDE3B"]
+        outputs: ["", "", "", "\uFFFD", "", "\uD83D\uDE3B"]
       },
       {
         inputs: [[0x3e, 0xd9, 0x3d], [0xd8], [0x3b, 0xde]],
-        outputs: ["", "\uD93E", "\uD83D\uDE3B"]
+        outputs: ["", "\uFFFD", "\uD83D\uDE3B"]
       },
       {
         inputs: [[0x3e, 0xd9, 0x3d]],
-        outputs: ["", "\uD93E�"]
+        outputs: ["", "�"]
       },
       {
         inputs: [[0x3e, 0xd9], [0x3d]],
-        outputs: ["", "", "\uD93E�"]
+        outputs: ["", "", "�"]
       },
       {
         inputs: [[0x3e, 0xd9]],
-        outputs: ["", "\uD93E"]
+        outputs: ["", "�"]
       }
     ])
   )
@@ -195,6 +204,22 @@ describe("UTF-16BE decoder #node-web", function () {
     assert.equal(iconv.decode(utils.bytes([0x61]), enc), "�")
   })
 
+  // See note in the UTF-16LE decoder above.
+  it("replaces unpaired surrogates with U+FFFD (per WHATWG)", function () {
+    // prettier-ignore
+    const buf = utils.bytes("0020 d800 0020 de00 0020 de00 d800 0020 d800")
+    assert.equal(iconv.decode(buf, enc), " � � �� �")
+  })
+
+  it("round-trips all non-surrogate BMP code points", function () {
+    let s = ""
+    for (let i = 0; i < 0x10000; i++) {
+      if (i >= 0xD800 && i <= 0xDFFF) continue // Surrogates aren't round-trippable per WHATWG.
+      s += String.fromCharCode(i)
+    }
+    assert.equal(iconv.decode(iconv.encode(s, enc), enc), s)
+  })
+
   it(
     "handles chunks with uneven lengths correctly",
     utils.checkDecoderChunks(enc, {
@@ -230,23 +255,23 @@ describe("UTF-16BE decoder #node-web", function () {
     utils.checkDecoderChunks(enc, [
       {
         inputs: [[0xd9], [0x3e], [0xd8], [0x3d], [0xde], [0x3b]],
-        outputs: ["", "", "", "\uD93E", "", "\uD83D\uDE3B"]
+        outputs: ["", "", "", "\uFFFD", "", "\uD83D\uDE3B"]
       },
       {
         inputs: [[0xd9, 0x3e, 0xd8], [0x3d], [0xde, 0x3b]],
-        outputs: ["", "\uD93E", "\uD83D\uDE3B"]
+        outputs: ["", "\uFFFD", "\uD83D\uDE3B"]
       },
       {
         inputs: [[0xd9, 0x3e, 0xd8]],
-        outputs: ["", "\uD93E�"]
+        outputs: ["", "�"]
       },
       {
         inputs: [[0xd9, 0x3e], [0xd8]],
-        outputs: ["", "", "\uD93E�"]
+        outputs: ["", "", "�"]
       },
       {
         inputs: [[0xd9, 0x3e]],
-        outputs: ["", "\uD93E"]
+        outputs: ["", "�"]
       }
     ])
   )
@@ -293,4 +318,62 @@ describe("UTF-16 decoder #node-web", function () {
       iconv.decode(weirdBuf, encBE)
     )
   })
+})
+
+// Adapted from @exodus/bytes' utf16 tests: unpaired/invalid surrogates must be replaced with
+// U+FFFD regardless of where they sit in the input. We re-check each case at a range of offsets,
+// which shifts the bad code unit around and guards against position/alignment-specific bugs.
+describe("UTF-16 decoder robustness #node-web", function () {
+  const orphans = [
+    { invalid: [0x61, 0x62, 0xD800, 0x77, 0x78], replaced: [0x61, 0x62, 0xFFFD, 0x77, 0x78] },
+    { invalid: [0xD800], replaced: [0xFFFD] },
+    { invalid: [0xD800, 0xD800], replaced: [0xFFFD, 0xFFFD] },
+    { invalid: [0x61, 0x62, 0xDFFF, 0x77, 0x78], replaced: [0x61, 0x62, 0xFFFD, 0x77, 0x78] },
+    { invalid: [0xDFFF, 0xD800], replaced: [0xFFFD, 0xFFFD] }
+  ]
+
+  function unitsToBytes (units, littleEndian) {
+    const bytes = []
+    for (const u of units) {
+      if (littleEndian) { bytes.push(u & 0xff, u >> 8) } else { bytes.push(u >> 8, u & 0xff) }
+    }
+    return utils.bytes(bytes)
+  }
+
+  for (const enc of ["utf-16le", "utf-16be"]) {
+    const le = enc === "utf-16le"
+    for (const { invalid, replaced } of orphans) {
+      const label = invalid.map((u) => u.toString(16)).join(",")
+      it(`replaces unpaired surrogates [${label}] at any offset (${enc})`, function () {
+        const expectedTail = String.fromCharCode.apply(null, replaced)
+        for (let p = 0; p <= 40; p++) {
+          const prefix = new Array(p).fill(0x20) // p spaces, shifting the bad unit's position.
+          const buf = unitsToBytes(prefix.concat(invalid), le)
+          assert.strictEqual(iconv.decode(buf, enc), " ".repeat(p) + expectedTail)
+        }
+      })
+    }
+  }
+})
+
+// Opt-in WHATWG "fatal" mode: { fatal: true } throws on invalid input instead of replacing with
+// U+FFFD. The default stays lenient (replacement), matching TextDecoder's own default.
+describe("UTF-16 decoder fatal mode (opt-in) #node-web", function () {
+  for (const enc of ["utf-16le", "utf-16be"]) {
+    const lone = enc === "utf-16le" ? utils.bytes("00d8") : utils.bytes("d800") // Lone high surrogate.
+    const odd = enc === "utf-16le" ? utils.bytes("610000") : utils.bytes("006100") // Truncated code unit.
+
+    it(`throws on invalid input when { fatal: true } (${enc})`, function () {
+      assert.throws(function () { iconv.decode(lone, enc, { fatal: true }) })
+      assert.throws(function () { iconv.decode(odd, enc, { fatal: true }) })
+    })
+
+    it(`still decodes valid input when { fatal: true } (${enc})`, function () {
+      assert.equal(iconv.decode(iconv.encode(testStr, enc), enc, { fatal: true }), testStr)
+    })
+
+    it(`replaces instead of throwing by default (${enc})`, function () {
+      assert.equal(iconv.decode(lone, enc), "�")
+    })
+  }
 })

--- a/test/wpt/shim.js
+++ b/test/wpt/shim.js
@@ -35,10 +35,11 @@ function normalizeLabel (label) {
   return String(label).replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, "").toLowerCase()
 }
 
-// The thrown error must be an instance of the *test realm's* RangeError for
-// assert_throws_js to accept it, so we use the jsdom window's constructor
+// The thrown error must be an instance of the *test realm's* RangeError/TypeError for
+// assert_throws_js to accept it, so we use the jsdom window's constructors
 // (captured in setup) rather than this module's.
 let RealmRangeError = RangeError
+let RealmTypeError = TypeError
 
 function toUint8Array (input) {
   if (input == null) return new Uint8Array()
@@ -58,15 +59,20 @@ class IconvTextDecoder {
     this._name = normalized
     // Report the WHATWG canonical name when known, else iconv's own label.
     this.encoding = whatwgLabels.get(normalized) || normalized
-    // iconv-lite has no streaming/fatal modes — expose the flags WPT reads, but
-    // { fatal: true } cannot throw (iconv always replaces), which is the real gap.
     this.fatal = Boolean(options.fatal)
     this.ignoreBOM = Boolean(options.ignoreBOM)
   }
 
   decode (input, options = {}) {
     const buf = Buffer.from(toUint8Array(input))
-    return iconv.decode(buf, this._name, { stripBOM: !this.ignoreBOM })
+    try {
+      return iconv.decode(buf, this._name, { stripBOM: !this.ignoreBOM, fatal: this.fatal })
+    } catch (e) {
+      // In fatal mode iconv throws a TypeError; rethrow it as the test realm's TypeError so
+      // assert_throws_js (which checks cross-realm instanceof) accepts it.
+      if (e instanceof TypeError) throw new RealmTypeError(e.message)
+      throw e
+    }
   }
 }
 
@@ -78,6 +84,7 @@ class IconvTextEncoder {
 
 module.exports = function setup (window) {
   RealmRangeError = window.RangeError || RangeError
+  RealmTypeError = window.TypeError || TypeError
   window.TextDecoder = IconvTextDecoder
   window.TextEncoder = IconvTextEncoder
 }


### PR DESCRIPTION
Basically, we can use the same `TextDecoder` implementation that Node.js uses. We still keep the aliases, and we preserve the logic for detecting whether the encoding is `utf-16le` or `utf-16be`.

We also now support the `fatal` option, if the user wants to enable it.

