### PR TITLE
fix(dbcs): stop the decoder emitting ill-formed UTF-16

### DIFF
--- a/encodings/dbcs-codec.js
+++ b/encodings/dbcs-codec.js
@@ -14,6 +14,12 @@ var NODE_START = -1000
 var UNASSIGNED_NODE = new Array(0x100)
 var DEF_CHAR = -1
 
+// Pointer ranges left unassigned by the WHATWG "index gb18030 ranges" table.
+// https://encoding.spec.whatwg.org/#index-gb18030-ranges-code-point
+var GB18030_GAP_START = 39420
+var GB18030_GAP_END = 189000
+var GB18030_MAX_POINTER = 1237575
+
 for (var i = 0; i < 0x100; i++) { UNASSIGNED_NODE[i] = UNASSIGNED }
 
 // Class DBCSCodec reads and initializes mapping tables.
@@ -433,7 +439,8 @@ function DBCSDecoder (options, codec) {
 }
 
 DBCSDecoder.prototype.write = function (buf) {
-  var newBuf = Buffer.alloc(buf.length * 2)
+  // A sequence finishing on carried-over bytes still emits its code units into this chunk.
+  var newBuf = Buffer.alloc((buf.length + this.prevBytes.length) * 2)
   var nodeIdx = this.nodeIdx
   var prevBytes = this.prevBytes; var prevOffset = this.prevBytes.length
   var seqStart = -this.prevBytes.length // idx of the start of current parsed sequence.
@@ -460,8 +467,13 @@ DBCSDecoder.prototype.write = function (buf) {
                           (((i - 1 >= 0) ? buf[i - 1] : prevBytes[i - 1 + prevOffset]) - 0x81) * 10 +
                           (curByte - 0x30)
       }
-      var idx = findIdx(this.gb18030.gbChars, ptr)
-      uCode = this.gb18030.uChars[idx] + ptr - this.gb18030.gbChars[idx]
+      if ((ptr >= GB18030_GAP_START && ptr < GB18030_GAP_END) || ptr > GB18030_MAX_POINTER) {
+        // Unassigned pointer: the ranges table would extrapolate a character that doesn't exist.
+        uCode = this.defaultCharUnicode.charCodeAt(0)
+      } else {
+        var idx = findIdx(this.gb18030.gbChars, ptr)
+        uCode = this.gb18030.uChars[idx] + ptr - this.gb18030.gbChars[idx]
+      }
     } else if (uCode <= NODE_START) { // Go to next trie node.
       nodeIdx = NODE_START - uCode
       continue

--- a/test/dbcs.test.js
+++ b/test/dbcs.test.js
@@ -701,3 +701,57 @@ describe("Full DBCS encoding tests", function () {
       })(enc) }
   }
 })
+
+describe("DBCS chunk boundaries", function () {
+  this.timeout(30000)
+
+  function decodeSplit (enc, bytes, at) {
+    var decoder = iconv.getDecoder(enc)
+    var str = decoder.write(Buffer.from(bytes.slice(0, at))) + decoder.write(Buffer.from(bytes.slice(at)))
+    return str + (decoder.end() || "")
+  }
+
+  // A sequence whose last byte arrives in a new chunk still emits every code unit it
+  // decodes to, so splitting the input must not change the result.
+  var encodings = []
+  for (var enc in iconv.encodings) {
+    if (iconv.encodings[enc].type === "_dbcs") encodings.push(enc)
+  }
+
+  encodings.forEach(function (enc) {
+    it("'" + enc + "' decodes 2 byte sequences the same when split", function () {
+      for (var b1 = 0x81; b1 <= 0xFE; b1++) {
+        for (var b2 = 0x21; b2 <= 0xFE; b2++) {
+          var bytes = [b1, b2]
+          var whole = iconv.decode(Buffer.from(bytes), enc)
+          var split = decodeSplit(enc, bytes, 1)
+          if (split !== whole) {
+            assert.fail(Buffer.from(bytes).toString("hex") + ": whole " + strToHex(whole) + ", split " + strToHex(split))
+          }
+        }
+      }
+    })
+  })
+
+  it("GB18030 decodes supplementary 4 byte sequences the same at every split", function () {
+    // Stride keeps this quick; the boundaries of the supplementary pointer range are always hit.
+    var pointers = [189000, 189001, 1237574, 1237575]
+    for (var p = 189000; p <= 1237575; p += 97) pointers.push(p)
+
+    for (var i = 0; i < pointers.length; i++) {
+      var ptr = pointers[i]
+      var bytes = [
+        Math.floor(ptr / 12600) + 0x81,
+        Math.floor((ptr % 12600) / 1260) + 0x30,
+        Math.floor((ptr % 1260) / 10) + 0x81,
+        (ptr % 10) + 0x30
+      ]
+      var whole = iconv.decode(Buffer.from(bytes), "gb18030")
+      assert.strictEqual(whole.length, 2, "pointer " + ptr + " should be a surrogate pair")
+      for (var at = 1; at <= 3; at++) {
+        assert.strictEqual(strToHex(decodeSplit("gb18030", bytes, at)), strToHex(whole),
+          "pointer " + ptr + " split after byte " + at)
+      }
+    }
+  })
+})

--- a/test/gbk.test.js
+++ b/test/gbk.test.js
@@ -126,4 +126,79 @@ describe("GBK tests", function () {
     assert.strictEqual(iconv.decode(gbkChars, "GB18030"), chars)
     assert.strictEqual(iconv.encode(chars, "GB18030").toString("hex"), gbkChars.toString("hex"))
   })
+
+  // Boundaries of the four pointer regions of https://encoding.spec.whatwg.org/#index-gb18030-ranges-code-point.
+  // Byte sequences and expectations are taken from the vendored upstream WPT file
+  // test/wpt/upstream/encoding/legacy-mb-schinese/gb18030/gb18030-decoder.any.js.
+  var pointerBoundaries = [
+    [39419, [0x84, 0x31, 0xA4, 0x39], "￿"],            // last assigned BMP pointer
+    [39420, [0x84, 0x31, 0xA5, 0x30], "�"],            // first pointer of the unassigned gap
+    [188999, [0x8F, 0x39, 0xFE, 0x39], "�"],           // last pointer of the unassigned gap
+    [189000, [0x90, 0x30, 0x81, 0x30], "𐀀"],     // first supplementary pointer, U+10000
+    [1237575, [0xE3, 0x32, 0x9A, 0x35], "􏿿"],    // last assigned pointer, U+10FFFF
+    [1237576, [0xE3, 0x32, 0x9A, 0x36], "�"],          // first pointer past the end
+    [1587599, [0xFE, 0x39, 0xFE, 0x39], "�"]           // highest 4-byte sequence
+  ]
+
+  it("GB18030 replaces 4 byte sequences whose pointer is unassigned", function () {
+    for (var i = 0; i < pointerBoundaries.length; i++) {
+      var buf = Buffer.from(pointerBoundaries[i][1])
+      assert.strictEqual(strToHex(iconv.decode(buf, "GB18030")), strToHex(pointerBoundaries[i][2]),
+        "pointer " + pointerBoundaries[i][0])
+    }
+  })
+
+  it("GB18030 never decodes a 4 byte sequence to an unpaired surrogate", function () {
+    this.timeout(30000)
+    var wellFormed = /^(?:[^\uD800-\uDFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF])*$/
+    var buf = Buffer.alloc(4)
+    for (var b1 = 0x81; b1 <= 0xFE; b1++) {
+      buf[0] = b1
+      for (var b2 = 0x30; b2 <= 0x39; b2++) {
+        buf[1] = b2
+        for (var b3 = 0x81; b3 <= 0xFE; b3++) {
+          buf[2] = b3
+          for (var b4 = 0x30; b4 <= 0x39; b4++) {
+            buf[3] = b4
+            var str = iconv.decode(buf, "GB18030")
+            if (!wellFormed.test(str)) { assert.fail(buf.toString("hex") + " decoded to ill-formed UTF-16 " + strToHex(str)) }
+          }
+        }
+      }
+    }
+  })
+
+  it("GB18030 decodes every 4 byte sequence like the platform decoder", function () {
+    this.timeout(30000)
+    if (typeof TextDecoder !== "function") { this.skip() }
+    var native
+    try { native = new TextDecoder("gb18030") } catch (_e) { return this.skip() }
+
+    // A small-icu build resolves the label but decodes as windows-1252, so check the
+    // reference answers before trusting it.
+    for (var i = 0; i < pointerBoundaries.length; i++) {
+      if (native.decode(Uint8Array.from(pointerBoundaries[i][1])) !== pointerBoundaries[i][2]) { return this.skip() }
+    }
+
+    var buf = Buffer.alloc(4)
+    var checked = 0
+    for (var b1 = 0x81; b1 <= 0xFE; b1++) {
+      buf[0] = b1
+      for (var b2 = 0x30; b2 <= 0x39; b2++) {
+        buf[1] = b2
+        for (var b3 = 0x81; b3 <= 0xFE; b3++) {
+          buf[2] = b3
+          for (var b4 = 0x30; b4 <= 0x39; b4++) {
+            buf[3] = b4
+            var expected = native.decode(buf)
+            if (iconv.decode(buf, "GB18030") !== expected) {
+              assert.fail(buf.toString("hex") + ": got " + strToHex(iconv.decode(buf, "GB18030")) + ", expected " + strToHex(expected))
+            }
+            checked++
+          }
+        }
+      }
+    }
+    assert.strictEqual(checked, 126 * 10 * 126 * 10)
+  })
 })


### PR DESCRIPTION
`iconv.decode(Buffer.from([0x84, 0x31, 0xA5, 0x30]), 'gb18030')` returns U+10000 — the same character as the valid `90 30 81 30` — where the WHATWG standard and every platform decoder return U+FFFD: `findIdx` is an unbounded "last range start <= value" search over `gb18030-ranges.json` and nothing bounds the pointer from above, so the last range gets extrapolated across both unassigned pointer regions. All 499,604 spec-invalid 4-byte sequences decode to a character, and the 350,024 past pointer 1237575 run beyond U+10FFFF into unpaired surrogates (`E3 32 9A 36` gives U+DC00 U+DC00), while all 1,087,996 assigned sequences are unchanged — I swept the whole 4-byte space against Node's `TextDecoder('gb18030')`, CPython's `gb18030` codec and libiconv, and the three agree exactly on which pointers are assigned.

Measuring that turned up a second one in the same function: `DBCSDecoder.prototype.write` sizes its output buffer from the current chunk alone, so a sequence finishing on bytes carried over from the previous `write()` silently loses code units. Every valid supplementary gb18030 character split after its third byte comes back as a lone U+D800, and 44,863 two-byte cases across all eight DBCS codecs decode differently split than whole (1,717 of those are valid Big5 plane-2 characters).

Tests add the seven pointer-region boundaries from the vendored upstream WPT file, a check that no 4-byte sequence yields ill-formed UTF-16, the full-space differential against the platform decoder (skipped when the runtime has no gb18030), and split-vs-whole for every DBCS codec; `npm test` goes 406 to 418, and `test:node-web`, `test:typescript` and lint are green. One caveat about #400 — the counts there will not move, because the upstream file asserts every vector under both `gb18030` and `gbk` in a single test and `gbk` is still a genuine 2-byte codec here. Under the `gb18030` label alone the failures go 8 to 4; the remaining four are the separate 2-byte error-recovery behaviour, which I left alone.
